### PR TITLE
add missing dep: bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "async": "^1.5.2",
     "bcryptjs": "^2.3.0",
     "body-parser": "*",
+    "bluebird": "3.5.0",
     "colors": "^1.1.2",
     "compression": "*",
     "connect-busboy": "0.0.2",


### PR DESCRIPTION
at the moment only tests require it, but it will be needed also in implementation side so that why I added it to direct dependency..