### PR TITLE
Update .coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,1 @@
-service_name: travis-pro
 repo_token: FlGGWQ9I5wlP8tRFjpmfkYJvJquW74rqd


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Because project are not using travis anymore.. Moved to CircleCI because it provide better artifactor storage..