### PR TITLE
get rid of node-restify-mongoose

### DIFF
--- a/app/routes/groups.js
+++ b/app/routes/groups.js
@@ -1,17 +1,31 @@
 const mongoose = require('mongoose');
-const restify = require('express-restify-mongoose');
 const _ = require('lodash');
 const logger = require('winston');
+const express = require('express');
+// application modules
+const GroupController = require('../controllers/groups');
 
 const Route = function (app) {
   // easy way, but not support format -functionality..
   const Group = mongoose.model('Group');
-  restify.serve(app, Group, {
-    version: '/v0',
-    name: 'groups',
-    idProperty: '_id',
-    protected: '__v',
-  });
+
+  const router = express.Router();
+  const controller = new GroupController();
+
+  router.param('Group', controller.modelParam.bind(controller));
+
+  router.route('/api/v0/groups.:format?')
+    .all(controller.all.bind(controller))
+    .get(controller.find.bind(controller))
+    .post(controller.create.bind(controller));
+
+  router.route('/api/v0/groups/:Group.:format?')
+    .all(controller.all.bind(controller))
+    .get(controller.get.bind(controller))
+    .put(controller.update.bind(controller))
+    .delete(controller.remove.bind(controller));
+
+  app.use(router);
 
   Group.count({}, (err, count) => {
     if (count === 0) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "csurf": "^1.9.0",
     "express": "^4.15.3",
     "express-jwt": "^5.1.0",
-    "express-restify-mongoose": "^0.7.5",
     "express-session": "^1.15.3",
     "express-winston": "^2.4.0",
     "fs-extra": "^4.0.0",


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
get rid of node-testify-mongoose because it has Private Data Disclosure - not open enough for this project. It was used in groups before but now replaced with same approach than other routes.