### PR TITLE
initial routes for optimizing the result uploading process

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -94,6 +94,10 @@ class DefaultController extends EventEmitter {
       if (error) {
         logger.warn(error);
         res.status(400).json({error: error.message});
+      } else if (!doc) {
+        const errorMsg = `Could not find ${this.modelName} with _id ${editedReq.params[this.modelName]}`;
+        logger.warn(errorMsg);
+        res.status(404).json({error: errorMsg});
       } else {
         this.emit('update', doc.toObject());
         res.json(doc);

--- a/app/controllers/testcases.js
+++ b/app/controllers/testcases.js
@@ -5,10 +5,17 @@
 // native modules
 const request = require('request');
 
-// 3rd party modules
-
 // own modules
 const DefaultController = require('./');
+const ResultController = require('../controllers/results');
+
+// Controller variables
+const resultController = new ResultController();
+const updateOptions = {
+  upsert: true,
+  runValidators: true,
+  new: true
+};
 
 class TestcasesController extends DefaultController {
   constructor() { super('Testcase'); }
@@ -29,6 +36,49 @@ class TestcasesController extends DefaultController {
     } else {
       res.status(404).json({error: 'nothing to download'});
     }
+  }
+
+  upsert(req, res) {
+    if (!req.body.tcid) {
+      return res.status(400).json({error: 'Expected request body to contain a tcid property'});
+    }
+
+    return this._model.findOneAndUpdate({tcid: req.body.tcid}, req.body, updateOptions)
+      .exec()
+      .then((updatedTestcase) => {
+        const statusCode = updatedTestcase.isNew ? 201 : 200;
+        res.status(statusCode).json(updatedTestcase.toObject());
+      }).catch((error) => {
+        res.status(400).json({error: error.message});
+      });
+  }
+
+  upsertAndAddResult(req, res) {
+    const testcaseBody = req.body.testcase;
+    const resultBody = req.body.result;
+
+    if (!testcaseBody || !resultBody) {
+      return res.status(400).json({error:
+        'shortcut route for adding results to testcase needs both testcase and result properties'});
+    }
+
+    if (!testcaseBody.tcid) {
+      return res.status(400).json({error: 'Expected testcase body to contain a tcid property'});
+    }
+
+    return this._model.findOneAndUpdate({tcid: req.body.tcid}, testcaseBody, updateOptions)
+      .exec()
+      .then(() => {
+        if (!resultBody.tcid) {
+          resultBody.tcid = testcaseBody.tcid;
+        }
+
+        req.body = resultBody;
+        return resultController.create(req, res);
+      })
+      .catch((error) => {
+        res.status(400).json({error: error.message});
+      });
   }
 }
 

--- a/app/routes/testcases.js
+++ b/app/routes/testcases.js
@@ -10,7 +10,12 @@ function Route(app) {
   router.route('/api/v0/testcases.:format?')
     .all(controller.all.bind(controller))
     .get(controller.find.bind(controller))
-    .post(controller.create.bind(controller));
+    .post(controller.create.bind(controller))
+    .put(controller.upsert.bind(controller));
+
+  router.route('/api/v0/testcases/result.:format?')
+    .all(controller.all.bind(controller))
+    .post(controller.upsertAndAddResult.bind(controller));
 
   router.route('/api/v0/testcases/:testcase.:format?')
     .all(controller.all.bind(controller))


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
This pr creates 2 new routes that can be used to minimize requests needed to upload testcase results. One is the basic upsert and the other combines this upsert operation and result upload into one request.

## Todos
- [ ] Tests

## Impacted Areas in Application
* routes/testcases.js
* controllers/testcases.js
* test/routes/testcases.js
* test/controllers/testcases.js
