### PR TITLE
Testcase route update failing - fix

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -89,8 +89,13 @@ class DefaultController extends EventEmitter {
     delete editedReq.body.__v;
     logger.debug(editedReq.body);
 
+    const modelID = editedReq.params[this.modelName];
+    if (modelID === undefined) {
+      return res.status(500).json({error: 'Failed to extract id from request params.'});
+    }
+
     const updateOpts = {runValidators: true};
-    this._model.findByIdAndUpdate(editedReq.params[this.modelName], editedReq.body, updateOpts, (error, doc) => {
+    this._model.findByIdAndUpdate(modelID, editedReq.body, updateOpts, (error, doc) => {
       if (error) {
         logger.warn(error);
         res.status(400).json({error: error.message});

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -104,6 +104,8 @@ class DefaultController extends EventEmitter {
         res.json(doc);
       }
     });
+
+    return undefined;
   }
 
   remove(req, res) {

--- a/app/routes/testcases.js
+++ b/app/routes/testcases.js
@@ -12,13 +12,13 @@ function Route(app) {
     .get(controller.find.bind(controller))
     .post(controller.create.bind(controller));
 
-  router.route('/api/v0/testcases/:testcase.:format?')
+  router.route('/api/v0/testcases/:Testcase.:format?')
     .all(controller.all.bind(controller))
     .get(controller.get.bind(controller))
     .put(controller.update.bind(controller))
     .delete(controller.remove.bind(controller));
 
-  router.route('/api/v0/testcases/:testcase/download')
+  router.route('/api/v0/testcases/:Testcase/download')
     .all(controller.all.bind(controller))
     .get(controller.download.bind(controller));
 


### PR DESCRIPTION
## Status
**READY**

## Description
Testcases cannot be updated through API, this pr fixes that bug.

Bug was caused by testcase router extracting testcase id parameter with name "testcase". This caused the default controller to not find the mentioned parameter in the update function and thus leading to errors.

Solution, fix router to extract testcase id parameter as "Testcase".

## Impacted Areas in Application
* controllers/index.js
* routes/testcases.js