### PR TITLE
remove NODE_ENV selection from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "node": "0.10.x"
   },
   "scripts": {
-    "start": "NODE_ENV=development node index.js",
-    "cluster": "NODE_ENV=development node app/cluster.js",
-    "debug": "NODE_ENV=development node --inspect index.js",
-    "debug-cluster": "NODE_ENV=development node --inspect app/cluster.js",
+    "start": "node index.js",
+    "cluster": "node app/cluster.js",
+    "debug": "node --inspect index.js",
+    "debug-cluster": "node --inspect app/cluster.js",
     "test": "grunt",
     "lint": "node node_modules/eslint/bin/eslint ."
   },


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
it should be user responsibility to select which `NODE_ENV` to be used so removed it from package.json scripts..