### PR TITLE
Rework addon loading pipeline for cronjobs

### DIFF
--- a/app/addons/sample/index.js
+++ b/app/addons/sample/index.js
@@ -1,10 +1,13 @@
+// Third party components
 const express = require('express');
+
+// Application components
 const logger = require('../../tools/logger');
+
 
 class AddonCore {
   constructor(app, server, io) {
     // Defined variables
-    this.router = express.Router();
     this.staticPath = { prefix: '/test', folder: '/public/' };
 
     // Own variables
@@ -14,6 +17,7 @@ class AddonCore {
 
   // Default implementation of register
   register() {
+    this.router = express.Router();
     logger.warn('registering instance of sample class');
     this.router.get('/test', (req, res) => {
       res.json({ ok: 1 });
@@ -32,6 +36,10 @@ class AddonCore {
 
   unregister() {
     logger.warn('unregistering instance of sample class');
+  }
+
+  startJobs() {
+    logger.warn('starting jobs for sample class');
   }
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -44,18 +44,18 @@ DB.connect().catch((error) => {
   .then(() => express(app))
   .then(() => routes.registerRoutes(app))
   .then(() => AddonManager.init(app, server, io))
+  .then(() => AddonManager.readAddons())
   .then(() => {
+    // Run only if server is handled by the master process
     if (cluster.isMaster) {
-      return AddonManager.readAddons()
+      return AddonManager.clearJobLocks()
         .then(() => AddonManager.installAddons());
     }
-
-    return AddonManager.readAddons();
+    return Promise.resolve();
   })
   .then(() => AddonManager.loadAddons())
   .then(() => AddonManager.registerAddons())
   .then(() => AddonManager.startJobs())
-  .then(() => routes.registerDelayRoute(app))
   // Error route should be initialized after addonmanager has served all static routes
   .then(() => routes.registerErrorRoute(app))
   .then(() => {

--- a/test/tests_unittests/addons/addon.js
+++ b/test/tests_unittests/addons/addon.js
@@ -246,18 +246,20 @@ describe('addon.js', function () {
     });
   });
 
+  describe('startJobs', function () {
+    // @TODO Do tests
+  });
+
+  describe('clearJobLock', function () {
+    // @TODO Do tests
+  });
+
   describe('_loadAddonModule', function () {
     it('_loadAddonModule', function () {
       global.createErrorMessage = error => Promise.reject(error);
 
       addonPrototype.constructor._requirePackageFile = () => Promise.resolve(
         {description: 'desc', version: 'version', repository: 'repo'});
-
-      let installCalled = false;
-      addonPrototype.constructor._installDependencies = () => {
-        installCalled = true;
-        return Promise.resolve();
-      };
 
       let checkCalled = false;
       addonPrototype.constructor._checkDependencies = () => {
@@ -275,7 +277,6 @@ describe('addon.js', function () {
         .then(() => {
           delete global.createErrorMessage;
 
-          expect(installCalled).to.equal(true);
           expect(checkCalled).to.equal(true);
           expect(requireCalled).to.equal(true);
 
@@ -286,8 +287,8 @@ describe('addon.js', function () {
     });
   });
 
-  describe('_installDependencies', function () {
-    it.skip('_installDependencies', function (done) {
+  describe('installDependencies', function () {
+    it.skip('installDependencies', function (done) {
       // TODO actually test that a command is executed
       done();
     });

--- a/test/tests_unittests/addons/index.js
+++ b/test/tests_unittests/addons/index.js
@@ -137,8 +137,18 @@ describe('addons/index.js', function () {
     });
   });
 
+  describe('readAddons', function () {
+    // @TODO Do tests
+  });
+
+  describe('installAddons', function () {
+    // @TODO Do tests
+  });
+
   describe('loadAddons', function () {
     it('loadAddons - recursive 2 valid addons', function () {
+      AddonManager.addons = ['addon1', 'addon2'];
+
       // Mock addon manager
       const addonProto = Object.getPrototypeOf(AddonManager);
       addonProto.constructor._recursiveLoad = (addonArray) => {
@@ -170,6 +180,14 @@ describe('addons/index.js', function () {
         return Promise.resolve();
       });
     });
+  });
+
+  describe('startJobs', function () {
+    // @TODO Do tests
+  });
+
+  describe('clearJobLocks', function () {
+    // @TODO Do tests
   });
 
   describe('findAddon', function () {

--- a/test/tests_unittests/master.js
+++ b/test/tests_unittests/master.js
@@ -46,6 +46,9 @@ describe('app/master.js', function () {
 
       Master.createFileListener = () => {};
       Master.activateFileListener = () => {};
+
+      Master._initAddons = () => Promise.resolve('Initted');
+      Master._forkWorkers = () => Promise.resolve('Forked');
     });
 
     it('should listen for process and cluster events', function (done) {
@@ -133,7 +136,7 @@ describe('app/master.js', function () {
       done();
     });
 
-    it('should call fork os.cpus().length times', function (done) {
+    it.skip('should call fork os.cpus().length times', function (done) {
       const cpus = os.cpus().length;
 
       // Overwrite fork so we do not actually fork a child process
@@ -147,6 +150,14 @@ describe('app/master.js', function () {
         done();
       }).catch(done);
     });
+  });
+
+  describe('_initAddons', function () {
+    // @TODO Do tests
+  });
+
+  describe('_forkWorkers', function () {
+    // @TODO Refactor relevant tests from initialize to here
   });
 
   describe('handleWorkerRestart', function () {


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
~This pr reworks existing addon loading pipeline so it will be possible for workers to run periodic jobs, aka. cronjobs.~
Feature put on hold, proposed solution is not scalable enough

## Todos
- [ ] Tests
- [ ] Documentation

## Impacted Areas in Application
* index.js
* master.js
* addons/*
