### PR TITLE
empty object when get non existing user settings

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -35,7 +35,8 @@ class UsersController extends DefaultController {
       const settings = _.get(req.User, key);
       res.json(settings);
     } else {
-      res.status(404).json({error: `No settings for ${namespace}`});
+      // no settings stored under that namespace - give empty object
+      res.json({});
     }
   }
   updateSettings(req, res) { // eslint-disable-line class-methods-use-this

--- a/test/tests_api/users.js
+++ b/test/tests_api/users.js
@@ -151,13 +151,14 @@ describe('Users', function () {
       });
   });
 
-  it('should not give unknown setting /users/<id>/settings/notexists GET', function (done) {
+  it('should default unknown settings to empty object /users/<id>/settings/notexists GET', function (done) {
     superagent.get(`${api}/users/${newUserId}/settings/notexists`)
       .set('authorization', authString)
       .end(function (error, res) {
         expect(res).to.be.a('Object');
-        expect(error).to.not.equal(null);
-        expect(res.status).to.equal(404);
+        expect(error).to.equal(null);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.deep.equal({});
         done();
       });
   });
@@ -197,9 +198,9 @@ describe('Users', function () {
           .set('authorization', authString)
           .end(function (checkError, checkRes) {
             expect(checkRes).to.be.a('Object');
-            expect(checkRes.status).to.equal(404);
-            expect(checkError).to.not.equal(null);
-            expect(checkRes.body).to.be.a('Object');
+            expect(checkRes.status).to.equal(200);
+            expect(checkError).to.equal(null);
+            expect(checkRes.body).to.deep.equal({});
             done();
           });
       });


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
Give empty object when get user settings even there is no settings stored under that namespace