### PR TITLE
Daily log rotation bugfix

### DIFF
--- a/app/tools/logger.js
+++ b/app/tools/logger.js
@@ -1,5 +1,6 @@
 // Native components
 const cluster = require('cluster');
+const path = require('path');
 
 // Third party components
 const Winston = require('winston');
@@ -43,7 +44,7 @@ class MasterLogger {
           level: silent ? 'error' : ['info', 'debug', 'verbose', 'silly'][verbose % 4]
         }),
         new (Winston.transports.DailyRotateFile)({
-          filename: './log/app.log',
+          filename: path.resolve(__dirname, '..', '..', 'log', 'app.log'),
           json: false,
           handleExceptions: false,
           level: fileLevel,

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "grunt-express-server": "^0.5.3",
     "grunt-simple-mocha": "^0.4.1",
     "grunt-wait-server": "*",
-    "mock-fs": "4.4.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.4.2",
     "mockgoose": "^7.3.3",

--- a/test/tests_unittests/addons/mocking/addon-mock-files.json
+++ b/test/tests_unittests/addons/mocking/addon-mock-files.json
@@ -1,12 +1,8 @@
 {
-  "app": {
-	"addons": {
-	  "mockAddon1": {
+	"mockAddon1": {
 		"index.js": "module.exports = {}"
-	  },
-	  "mockAddon2": {
+	},
+	"mockAddon2": {
 		"index.js": "module.exports = {}"
-	  }
 	}
-  }
 }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This pr updates how winston is initialized and especially how daily-logger is handled. Fixes the not working daily file rotation.

Secondary problem arose from daily logger trying to open a log file while mock-fs was running a mocked file system. This causes tests to fail, not always, but too often.

This pr also fixes the secondary issue around addon tests.

## Impacted Areas in Application
* tools/logger.js
