### PR TITLE
Bugfix for posting results with empty data

### DIFF
--- a/app/models/extends/file.js
+++ b/app/models/extends/file.js
@@ -26,8 +26,7 @@ FileSchema.set('toObject', {virtuals: true});
 
 FileSchema.virtual('hrefs').get(function getHrefs() {
   const hasHref = fileProvider && (fileProvider !== 'mongodb') && this.sha1;
-  const pathToFile = path.join(fileProvider, this.sha1);
-  return hasHref ? pathToFile : undefined;
+  return hasHref ? path.join(fileProvider, this.sha1) : undefined;
 });
 
 FileSchema.methods.prepareDataForStorage = function prepareDataForStorage() {


### PR DESCRIPTION
## Status
**READY**

## Description
This pr fixes the issue with server crashing if result with empty data is posted.
Root cause: path module trying to concat a string and undefined sha1, which causes an error.

## Impacted Areas in Application
* models/extends/file.js
* models/results.js