### PR TITLE
Change tests node_env to test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ function gruntSetup(grunt) {
     },
     exec: {
       restore_db: {
-        cmd: `sh ${dbPath} local ${dumpPath}`,
+        cmd: `bash ${dbPath} local ${dumpPath}`,
         stdout: false,
         stderr: false
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,108 +1,125 @@
-require('xunit-file');
+// Native components
 const fs = require('fs');
 const path = require('path');
 
+// Third party components
+require('xunit-file');
+
+// Grunt variables
 const dbPath = path.join('.', 'scripts', 'dbrestore.sh');
 const dumpPath = path.join('.', 'test', 'seeds', 'test_dump');
 
-function gruntSetup(grunt) {
-  const testFilesApi = ['test/tests_api/*.js'];
-  const testFilesUnit = [
-    'test/tests_unittests/*.js',
-    'test/tests_unittests/tools/*.js',
-    'test/tests_unittests/tools/**/*.js',
-    'test/tests_unittests/addons/*.js',
-    'test/tests_unittests/controllers/*.js',
-    'test/tests_unittests/routes/*.js'
-  ];
+const testFilesApi = ['test/tests_api/*.js'];
+const testFilesUnit = [
+  'test/tests_unittests/*.js',
+  'test/tests_unittests/tools/*.js',
+  'test/tests_unittests/tools/**/*.js',
+  'test/tests_unittests/addons/*.js',
+  'test/tests_unittests/controllers/*.js',
+  'test/tests_unittests/routes/*.js'
+];
 
-  grunt.initConfig({
-    express: {
-      test: {
-        options: {
-          delay: 15000,
-          script: 'index.js',
-          node_env: 'test',
-          args: ['-s'] // to more traces set -vvv instead of -s (silent)
-        }
-      }
-    },
-    waitServer: {
-      server: {
-        options: {
-          timeout: 30000,
-          url: 'http://localhost:3000/api/v0'
-        }
-      }
-    },
-    exec: {
-      restore_db: {
-        cmd: `bash ${dbPath} local ${dumpPath}`,
-        stdout: false,
-        stderr: false
-      }
-    },
-    simplemocha: {
+const gruntConfig = {
+  express: {
+    test: {
       options: {
-        globals: ['should', 'check'],
-        timeout: 120000,
-        ignoreLeaks: false
-      },
-      api: {
-        src: testFilesApi
-      },
-      unit: {
-        src: testFilesUnit
+        delay: 15000,
+        script: 'index.js',
+        node_env: 'test',
+        args: ['-s'] // to more traces set -vvv instead of -s (silent)
       }
     }
-  });
-
-  grunt.registerTask('FindApiTests', 'Find all tests under the addons', () => {
-    const root = 'app/addons';
-    function walk(_path) {
-      const items = fs.readdirSync(_path);
-      items.forEach((item) => {
-        const dirName = `${_path}/${item}`;
-        if (fs.statSync(dirName).isDirectory()) {
-          // find only directories that ends with /test
-          if (dirName.substr(dirName.length - 5) === '/test') {
-            // use only test directories that are in the root of the addon
-            if ((dirName.match(/\//g) || []).length === 3) {
-              // only add test js files that are in the root of the /test directory.
-              // if you need to include subdirs, modify this to: dirName + '/' + '**/*.js'
-              testFilesApi.push(`${dirName}/*.js`);
-            }
-          }
-          walk(dirName);
-        }
-      });
+  },
+  waitServer: {
+    server: {
+      options: {
+        timeout: 30000,
+        url: 'http://localhost:3000/api/v0'
+      }
     }
-    walk(root);
+  },
+  exec: {
+    restore_db: {
+      cmd: `bash ${dbPath} local ${dumpPath}`,
+      stdout: false,
+      stderr: false
+    }
+  },
+  simplemocha: {
+    options: {
+      globals: ['should', 'check'],
+      timeout: 120000,
+      ignoreLeaks: false
+    },
+    api: {
+      src: testFilesApi
+    },
+    unit: {
+      src: testFilesUnit
+    }
+  }
+};
+
+function listAddons() {
+  const root = 'app/addons';
+
+  return fs.readdirSync(root)
+    .map(item => path.join(root, item)) // Map items to actual paths to those items
+    .filter(itemPath => fs.statSync(itemPath).isDirectory()); // Filter only directories
+}
+
+function findAddonUnitTests() {
+  listAddons().forEach((addonPath) => {
+    // Read addon items
+    fs.readdirSync(addonPath)
+      .filter(item => item === 'unitTests') // Filter only items that are named unitTests
+      .map(item => path.join(addonPath, item)) // Map items to actual paths to those items
+      .filter(itemPath => fs.statSync(itemPath).isDirectory()) // filter only those paths that are directories
+      .forEach((testPath) => {
+        testFilesUnit.push(path.join(testPath, '*.js'));
+      });
   });
+}
+
+function findAddonApiTests() {
+  listAddons().forEach((addonPath) => {
+    // Read addon items
+    fs.readdirSync(addonPath)
+      .filter(item => item === 'apiTests') // Filter only items that are named apiTests
+      .map(item => path.join(addonPath, item)) // Map items to actual paths to those items
+      .filter(itemPath => fs.statSync(itemPath).isDirectory()) // filter only those paths that are directories
+      .forEach((testPath) => {
+        testFilesApi.push(path.join(testPath, '*.js'));
+      });
+  });
+}
+
+function gruntSetup(grunt) {
+  grunt.initConfig(gruntConfig);
 
   grunt.loadNpmTasks('grunt-wait-server');
   grunt.loadNpmTasks('grunt-express-server');
   grunt.loadNpmTasks('grunt-exec');
   grunt.loadNpmTasks('grunt-simple-mocha');
 
-  grunt.registerTask('default', [
-    'FindApiTests',
-    'simplemocha:unit',
-    'express:test',
-    'waitServer',
-    'exec:restore_db',
-    'simplemocha:api'
-  ]);
+  grunt.registerTask('findAddonUnitTests', findAddonUnitTests);
+  grunt.registerTask('findAddonApiTests', findAddonApiTests);
 
+  grunt.registerTask('unittests', [
+    'findAddonUnitTests',
+    'simplemocha:unit'
+  ]);
   grunt.registerTask('apitests', [
-    'FindApiTests',
+    'findAddonApiTests',
     'exec:restore_db',
     'express:test',
     'waitServer',
     'simplemocha:api'
   ]);
-
-  grunt.registerTask('unittests', ['simplemocha:unit']);
+  grunt.registerTask('default', [
+    'unittests',
+    'apitests'
+  ]);
 }
 
 

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -4,7 +4,7 @@ const testConfig = {
   port: process.env.OPENTMI_PORT || 3000,
   webtoken: process.env.WEBTOKEN || 'OpenTMI-toP-SeCRet-tOKEn',
   db: process.env.MONGODB || 'mongodb://localhost/opentmi_test',
-  filedb: process.env.FILE_DB || './data',
+  filedb: process.env.FILE_DB || './test/test_filedb_data',
   admin: {
     user: process.env.OPENTMI_ADMIN_USERNAME || 'admin',
     pwd: process.env.OPENTMI_ADMIN_PASSWORD || 'admin'

--- a/scripts/dbrestore.sh
+++ b/scripts/dbrestore.sh
@@ -14,7 +14,7 @@
 # Used if arg = 'local'
 LOCAL_MONGO_HOST="127.0.0.1"
 LOCAL_MONGO_PORT="27017" # default mongoDB port
-LOCAL_DB_NAME="opentmi_dev"
+LOCAL_DB_NAME="opentmi_test"
 
 # Used if arg = 'remote'
 REMOTE_MONGO_HOST=""


### PR DESCRIPTION
## Status
**READY**

## Description
This pr aims to separate the testing environment from development environment. This allows for example tests that expect filedb to contain specific logs.

Since fiddling with grunt tasks is time consuming, this pr also changes the dbrestore.sh to work on both linux and windows without modifications. 

## Impacted Areas in Application
* gruntfile.js
* scripts
