### PR TITLE
fix git commitId in version API response

### DIFF
--- a/app/controllers/admin.js
+++ b/app/controllers/admin.js
@@ -18,7 +18,7 @@ class AdminController {
   }
 
   version(req, resp) {
-    this._updater.version()
+    this._updater.version(_.get(req.query, 'deep', false))
       .then(version => resp.json(version))
       .catch((error) => {
         logger.warn(error);

--- a/app/tools/update/gitUpdater.js
+++ b/app/tools/update/gitUpdater.js
@@ -37,8 +37,8 @@ class GitUpdater extends Updater {
 
   version() {
     const gitVersion = this._commitId()
-      .then(commitId => this._tag(commitId)
-        .then(tag => Object.assign({commitID: commitId}, tag)));
+      .then(obj => this._tag(obj.commitId)
+        .then(tag => Object.assign({commitId: obj.commitId}, tag)));
 
     return Promise
       .all([super.version(), gitVersion])
@@ -52,7 +52,7 @@ class GitUpdater extends Updater {
     });
   }
 
-  _tag(commitId = this._commitId()) {
+  _tag(commitId) {
     const cmd = `git describe --exact-match --tags ${commitId}`;
     return this.exec(cmd, this._options)
       .then(line => ({tag: line.trim()}))

--- a/app/tools/update/gitUpdater.js
+++ b/app/tools/update/gitUpdater.js
@@ -35,13 +35,12 @@ class GitUpdater extends Updater {
       });
   }
 
-  version() {
+  version(deep = false) {
     const gitVersion = this._commitId()
       .then(obj => this._tag(obj.commitId)
         .then(tag => Object.assign({commitId: obj.commitId}, tag)));
-
     return Promise
-      .all([super.version(), gitVersion])
+      .all([super.version(deep), gitVersion])
       .then(versions => Object.assign({}, versions[0], versions[1]));
   }
 

--- a/app/tools/update/npm.js
+++ b/app/tools/update/npm.js
@@ -16,8 +16,12 @@ class Npm {
     this.exec = execModule;
   }
 
-  list(execOptions, deep = false) {
-    const cmd = deep ? 'npm list --json --depth=0 --prod' : 'npm version --json';
+  /**
+   * Get version from `npm list`
+   * @param execOptions
+   */
+  list(execOptions) {
+    const cmd = 'npm list --json --depth=0 --prod';
     // @todo if dependencies has messed up this might be rejected.
     // uncomment above line to ignore stderr and pass everytime
     // cmd += ' 2>/dev/null || true';
@@ -27,6 +31,24 @@ class Npm {
       .then(stdout => JSON.parse(stdout))
       .catch((error) => {
         throw new Error(`npm list failed: ${error.message}`);
+      });
+  }
+
+  /**
+   * get results from `npm version`
+   * @param {object} execOptions
+   */
+  version(execOptions) {
+    const cmd = 'npm version --json';
+    // @todo if dependencies has messed up this might be rejected.
+    // uncomment above line to ignore stderr and pass everytime
+    // cmd += ' 2>/dev/null || true';
+    logger.silly('Reading npm packages');
+    const _options = Object.assign({maxBuffer: 1024 * 1024}, execOptions);
+    return this.exec(cmd, _options)
+      .then(stdout => JSON.parse(stdout))
+      .catch((error) => {
+        throw new Error(`npm version failed: ${error.message}`);
       });
   }
 

--- a/app/tools/update/npm.js
+++ b/app/tools/update/npm.js
@@ -16,8 +16,11 @@ class Npm {
     this.exec = execModule;
   }
 
-  list(execOptions) {
-    const cmd = 'npm list --json --depth=0 --prod';
+  list(execOptions, deep = false) {
+    const cmd = deep ? 'npm list --json --depth=0 --prod' : 'npm version --json';
+    // @todo if dependencies has messed up this might be rejected.
+    // uncomment above line to ignore stderr and pass everytime
+    // cmd += ' 2>/dev/null || true';
     logger.silly('Reading npm packages');
     const _options = Object.assign({maxBuffer: 1024 * 1024}, execOptions);
     return this.exec(cmd, _options)
@@ -28,10 +31,10 @@ class Npm {
   }
 
   /**
-   * 
-   * @param {*} execOptions 
+   *
+   * @param {*} execOptions
    * @param {*} options
-   * @todo emit installation stream back to client/admin 
+   * @todo emit installation stream back to client/admin
    */
   install(execOptions, options = '--on-optional --only=production') {
     const cmd = `npm install ${options}`;

--- a/app/tools/update/updater.js
+++ b/app/tools/update/updater.js
@@ -72,7 +72,10 @@ class Updater extends EventEmitter {
     if (this._pending.isPending()) {
       return Promise.reject('Cannot fetch version, pending action exists.');
     }
-    return this.npm.list(this._options, deep);
+    return Promise.all([
+      this.npm.version(this._options),
+      deep ? this.npm.list(this._options) : Promise.resolve({})]  )
+      .then((results) => Object.assign({}, results[0], results[1]))
   }
 
   restart() {

--- a/app/tools/update/updater.js
+++ b/app/tools/update/updater.js
@@ -74,8 +74,8 @@ class Updater extends EventEmitter {
     }
     return Promise.all([
       this.npm.version(this._options),
-      deep ? this.npm.list(this._options) : Promise.resolve({})]  )
-      .then((results) => Object.assign({}, results[0], results[1]))
+      deep ? this.npm.list(this._options) : Promise.resolve({})])
+      .then(results => Object.assign({}, results[0], results[1]));
   }
 
   restart() {

--- a/app/tools/update/updater.js
+++ b/app/tools/update/updater.js
@@ -68,11 +68,11 @@ class Updater extends EventEmitter {
     return Promise.reject(new Error('Not implemented'));
   }
 
-  version() {
+  version(deep) {
     if (this._pending.isPending()) {
       return Promise.reject('Cannot fetch version, pending action exists.');
     }
-    return this.npm.list(this._options);
+    return this.npm.list(this._options, deep);
   }
 
   restart() {

--- a/test/tests_api/app.init.js
+++ b/test/tests_api/app.init.js
@@ -56,6 +56,23 @@ describe('Basic Get API', function () {
         expect(res.body).to.have.a('Object');
         expect(res.body).to.not.be.empty;
         expect(res.body.commitId).to.have.a('string');
+        expect(res.body.OpenTMI).to.have.a('string');
+        expect(res.body.dependencies).to.not.exist;
+        done();
+      });
+  });
+  it('get server version deep', function (done) {
+    this.timeout(5000);
+    superagent.get(`${api}/version?deep=true`)
+      .set('authorization', authString)
+      .end(function (error, res) {
+        expect(error).to.equal(null);
+        expect(res).to.be.a('Object');
+        expect(res).to.have.property('status', 200);
+        expect(res.body).to.have.a('Object');
+        expect(res.body).to.not.be.empty;
+        expect(res.body.commitId).to.have.a('string');
+        expect(res.body.dependencies).to.have.a('Object');
         done();
       });
   });

--- a/test/tests_api/app.init.js
+++ b/test/tests_api/app.init.js
@@ -46,6 +46,19 @@ describe('Basic Get API', function () {
         done();
       });
   });
+  it('get server version', function (done) {
+    superagent.get(`${api}/version`)
+      .set('authorization', authString)
+      .end(function (error, res) {
+        expect(error).to.equal(null);
+        expect(res).to.be.a('Object');
+        expect(res).to.have.property('status', 200);
+        expect(res.body).to.have.a('Object');
+        expect(res.body).to.not.be.empty;
+        expect(res.body.commitId).to.have.a('string');
+        done();
+      });
+  });
 
   it('get testcases', function (done) {
     superagent.get(`${api}/testcases`)

--- a/test/tests_unittests/tools/update/gitUpdater.js
+++ b/test/tests_unittests/tools/update/gitUpdater.js
@@ -193,7 +193,8 @@ describe('update/gitUpdater', function () {
       it('should fetch git version and combine it with super.version', function () {
         gitUpdater = new GitUpdater(undefined, undefined);
 
-        gitUpdater._commitId = () => Promise.resolve('COMMIT_ID');
+        gitUpdater._commitId = () => Promise.resolve({commitId: 'COMMIT_ID'});
+
 
         gitUpdater._tag = (commitId) => {
           expect(commitId).to.equal('COMMIT_ID');
@@ -204,7 +205,7 @@ describe('update/gitUpdater', function () {
           Promise.resolve({superVersion: 'SUPER_VERSION'});
 
         return expect(gitUpdater.version()).to.eventually.deep.equal({
-          commitID: 'COMMIT_ID',
+          commitId: 'COMMIT_ID',
           tag: 'TAG',
           superVersion: 'SUPER_VERSION'
         });

--- a/test/tests_unittests/tools/update/npm.js
+++ b/test/tests_unittests/tools/update/npm.js
@@ -29,17 +29,7 @@ describe('update/npm.js', function () {
     const execOptions = {key1: 10, key2: '50a', key3: () => 92};
 
     describe('list', function () {
-      it('should execute a command with specified options', function () {
-        npm = new Npm((command, options) => {
-          expect(command).to.equal('npm version --json');
-          expect(options).to.deep.equal(Object.assign({}, {maxBuffer: 1024 * 1024}, execOptions));
-          return Promise.resolve('{"key1":"value1","key2":"value2"}');
-        });
-
-        return expect(npm.list(execOptions)).to.eventually.deep.equal(
-          {key1: 'value1', key2: 'value2'});
-      });
-      it('should execute deep list a command with specified options', function () {
+      it('should execute list a command with specified options', function () {
         npm = new Npm((command, options) => {
           expect(command).to.equal('npm list --json --depth=0 --prod');
           expect(options).to.deep.equal(Object.assign({}, {maxBuffer: 1024 * 1024}, execOptions));
@@ -53,6 +43,24 @@ describe('update/npm.js', function () {
       it('should be rejected when execute fails', function () {
         npm = new Npm(() => Promise.reject(new Error('Mock Error from test')));
         return expect(npm.list(execOptions)).to.be.rejectedWith(Error, 'npm list failed: ');
+      });
+    });
+
+    describe('version', function () {
+      it('should execute version a command with specified options', function () {
+        npm = new Npm((command, options) => {
+          expect(command).to.equal('npm version --json');
+          expect(options).to.deep.equal(Object.assign({}, {maxBuffer: 1024 * 1024}, execOptions));
+          return Promise.resolve('{"key1":"value1","key2":"value2"}');
+        });
+
+        return expect(npm.version(execOptions)).to.eventually.deep.equal(
+          {key1: 'value1', key2: 'value2'});
+      });
+
+      it('should be rejected when execute fails', function () {
+        npm = new Npm(() => Promise.reject(new Error('Mock Error from test')));
+        return expect(npm.version(execOptions)).to.be.rejectedWith(Error, 'npm version failed: ');
       });
     });
 

--- a/test/tests_unittests/tools/update/npm.js
+++ b/test/tests_unittests/tools/update/npm.js
@@ -31,12 +31,22 @@ describe('update/npm.js', function () {
     describe('list', function () {
       it('should execute a command with specified options', function () {
         npm = new Npm((command, options) => {
-          expect(command).to.equal('npm list --json --depth=0 --prod');
+          expect(command).to.equal('npm version --json');
           expect(options).to.deep.equal(Object.assign({}, {maxBuffer: 1024 * 1024}, execOptions));
           return Promise.resolve('{"key1":"value1","key2":"value2"}');
         });
 
         return expect(npm.list(execOptions)).to.eventually.deep.equal(
+          {key1: 'value1', key2: 'value2'});
+      });
+      it('should execute deep list a command with specified options', function () {
+        npm = new Npm((command, options) => {
+          expect(command).to.equal('npm list --json --depth=0 --prod');
+          expect(options).to.deep.equal(Object.assign({}, {maxBuffer: 1024 * 1024}, execOptions));
+          return Promise.resolve('{"key1":"value1","key2":"value2"}');
+        });
+
+        return expect(npm.list(execOptions, true)).to.eventually.deep.equal(
           {key1: 'value1', key2: 'value2'});
       });
 

--- a/test/tests_unittests/tools/update/updater.js
+++ b/test/tests_unittests/tools/update/updater.js
@@ -177,10 +177,11 @@ describe('update/updater.js', function () {
           expect(options).to.have.property('cwd', 'CWDD');
           expect(options).to.have.property('env');
           expect(options.env).to.have.property('ENV', 'ENVV');
-          return Promise.resolve('NpmListData');
+          return Promise.resolve({data: 'NpmListData'});
         };
+        updater.npm.version = (options) => Promise.resolve({});
 
-        return expect(updater.version()).to.eventually.equal('NpmListData');
+        return expect(updater.version(true)).to.eventually.equal({data: 'NpmListData'});
       });
 
       it('should return rejected Promise when _pending is pending', function () {

--- a/test/tests_unittests/tools/update/updater.js
+++ b/test/tests_unittests/tools/update/updater.js
@@ -181,7 +181,7 @@ describe('update/updater.js', function () {
         };
         updater.npm.version = () => Promise.resolve({});
 
-        return expect(updater.version(true)).to.eventually.equal({data: 'NpmListData'});
+        return expect(updater.version(true)).to.eventually.deep.equal({data: 'NpmListData'});
       });
 
       it('should return rejected Promise when _pending is pending', function () {

--- a/test/tests_unittests/tools/update/updater.js
+++ b/test/tests_unittests/tools/update/updater.js
@@ -179,7 +179,7 @@ describe('update/updater.js', function () {
           expect(options.env).to.have.property('ENV', 'ENVV');
           return Promise.resolve({data: 'NpmListData'});
         };
-        updater.npm.version = (options) => Promise.resolve({});
+        updater.npm.version = () => Promise.resolve({});
 
         return expect(updater.version(true)).to.eventually.equal({data: 'NpmListData'});
       });


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
commit id was not properly in API when requesting version.

added option to fetch just brief information (`npm version`) because `npm list` takes quite long time. deep version details can be fetched by query parameter `deep=true`

## Related PRs
#94 

## Todos
- [x] Tests
