### PR TITLE
rework socketio to use authentication

### DIFF
--- a/app/controllers/socketio.js
+++ b/app/controllers/socketio.js
@@ -1,0 +1,37 @@
+// 3rd party modules
+const _ = require('lodash');
+
+// Application modules
+const logger = require('../tools/logger');
+
+
+class SocketIOController {
+  constructor(socket) {
+    this._socket = socket;
+    logger.info(`New IO connection: ${this.decodedToken._id} ${this.isAdmin ? 'admin' : ''}`);
+  }
+  get decodedToken() {
+    return this._socket.decoded_token;
+  }
+  get _id() {
+    return this.decodedToken._id;
+  }
+  /*
+  user() {
+    // @todo need one more abstraction between controller and mongoose..
+    return User.findById(this._id).exec();
+  } */
+  get isAdmin() {
+    const groups = _.get(this.decodedToken, 'groups', []);
+    return _.find(groups, {name: 'admins'}) !== -1;
+  }
+  disconnect() {
+    logger.info(`IO client disconnected: ${this.decodedToken._id}`);
+  }
+  whoami(callback) {
+    logger.silly('whoami via IO called..');
+    callback(null, _.defaults(this.decodedToken, {isAdmin: this.isAdmin}));
+  }
+}
+
+module.exports = SocketIOController;

--- a/app/controllers/socketio.js
+++ b/app/controllers/socketio.js
@@ -10,7 +10,7 @@ const User = mongoose.model('User');
 class SocketIOController {
   constructor(socket) {
     this._socket = socket;
-    logger.info(`New IO connection: ${this.id} ${this.isAdmin ? 'admin' : ''}`);
+    logger.info(`New ${this.isAdmin ? 'admin' : 'user'} (ip: ${this.ipAddress}, id: ${this.id}) connected to IO`);
     logger.silly(`Current clients: ${Object.keys(SocketIOController.clients).length}`);
     SocketIOController.clients[this.id] = this;
     this._lastActivity = new Date();
@@ -21,7 +21,7 @@ class SocketIOController {
    */
   disconnect() {
     delete SocketIOController.clients[this.id];
-    logger.info(`IO client disconnected: ${this.id}`);
+    logger.info(`IO ${this.isAdmin ? 'admin' : 'user'} (ip: ${this.ipAddress}, id: ${this.id}) disconnected`);
   }
 
   /**
@@ -52,6 +52,10 @@ class SocketIOController {
     const promise = Promise.resolve(this._lastActivity);
     this._lastActivity = new Date();
     return promise;
+  }
+
+  get ipAddress() {
+    return _.get(this._socket, 'request.connection.remoteAddress');
   }
   get lastActivity() {
     return this._lastActivity;

--- a/app/index.js
+++ b/app/index.js
@@ -49,7 +49,7 @@ DB.connect().catch((error) => {
   process.exit(-1);
 }).then(() => models.registerModels())
   .then(() => express(app))
-  .then(() => routes.registerRoutes(app))
+  .then(() => routes.registerRoutes(app, io))
   .then(() => AddonManager.init(app, server, io))
   .then(() => AddonManager.loadAddons())
   .then(() => AddonManager.registerAddons())

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const Promise = require('bluebird');
 const logger = require('../tools/logger');
 
-function registerRoutes(app) {
+function registerRoutes(app, io) {
   logger.info('Adding Routers...');
   fs.readdirSync(__dirname).forEach((file) => {
     if (file.match(/\.js$/) && !file.match(/^(index|error)\.js$/)) {
@@ -14,7 +14,7 @@ function registerRoutes(app) {
       try {
         const router = require(`./${file}`); // eslint-disable-line global-require, import/no-dynamic-require
         if (typeof router === 'function') {
-          router(app);
+          router(app, io);
         } else {
           logger.warn('Router was not a function!');
         }

--- a/app/routes/socketio.js
+++ b/app/routes/socketio.js
@@ -1,0 +1,38 @@
+// Third party modules
+const socketioJwt = require('socketio-jwt');
+
+// Application modules
+const nconf = require('../../config');
+const Controller = require('../controllers/socketio');
+const logger = require('../tools/logger');
+
+// Route variables
+const TOKEN_SECRET = nconf.get('webtoken');
+
+function Route(app, io) {
+  let attemptToClose = false;
+  process.on('SIGINT', () => { attemptToClose = true; });
+  io.use((socket, next) => {
+    if (attemptToClose) {
+      logger.debug('client tried to open IO connection - server is going down...');
+      socket.disconnect(true);
+      return next(new Error('closing in progress..'));
+    }
+    return next();
+  });
+
+  // IO security
+  io.use(socketioJwt.authorize({
+    secret: TOKEN_SECRET,
+    handshake: true,
+    callback: false
+  }));
+
+  io.on('connection', (socket) => {
+    const controller = new Controller(socket);
+    socket.on('disconnect', controller.disconnect.bind(controller));
+    socket.on('whoami', controller.whoami.bind(controller));
+  });
+}
+
+module.exports = Route;

--- a/app/routes/socketio.js
+++ b/app/routes/socketio.js
@@ -1,5 +1,6 @@
 // Third party modules
 const socketioJwt = require('socketio-jwt');
+const _ = require('lodash');
 
 // Application modules
 const nconf = require('../../config');
@@ -28,10 +29,11 @@ function Route(app, io) {
     callback: false
   }));
 
+  const ioEvents = ['disconnect', 'whoami'];
+
   io.on('connection', (socket) => {
     const controller = new Controller(socket);
-    socket.on('disconnect', controller.disconnect.bind(controller));
-    socket.on('whoami', controller.whoami.bind(controller));
+    _.each(ioEvents, event => socket.on(event, controller[event].bind(controller)));
   });
 }
 

--- a/doc/APIs/authentication.md
+++ b/doc/APIs/authentication.md
@@ -1,7 +1,14 @@
 ## Authentication
 
+### Login
 ```
 POST /auth/login
+body: {username: <username>, password: <password>}
+response: {token: <token>}
+```
+
+
+```
 GET /auth/me
 PUT /auth/me
 POST /auth/signup

--- a/doc/APIs/readme.md
+++ b/doc/APIs/readme.md
@@ -22,8 +22,4 @@ There is JSON REST and SocketIO API's. REST provide most of the current features
 
 ## SocketIO API's
 
-## rooms:
-
-`/` default room
-
-`/admin` admin room
+Read more from [here](socketio.md)

--- a/doc/APIs/socketio.md
+++ b/doc/APIs/socketio.md
@@ -1,0 +1,31 @@
+## SocketIO
+
+### Authentication
+
+To use socketIO connection you have to use token. 
+To get token call [login](authentication.md) rest API.
+
+Usage example:
+```
+const options = {
+    query: `token=${token}`
+};
+const client = IO(host, options);
+```
+
+### Namespaces
+
+`/` default room
+
+`/admin` admin room
+
+### API's
+
+All query -kind of API's based on socketIO callback mechanism.
+
+#### Who Am I
+```
+io.emit('whoami', (error, data) => {
+    // data will contains user information
+});
+```

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "satellizer": "^0.15.5",
     "socket.io": "^2.0.3",
     "socket.io-adapter-mongo": "^2.0.0",
+    "socketio-jwt": "^4.5.0",
     "tv4": "^1.3.0",
     "uuid": "^3.1.0",
     "winston": "^2.3.1",

--- a/test/tests_api/socketio.js
+++ b/test/tests_api/socketio.js
@@ -6,6 +6,7 @@ const nconf = require('../../config');
 const moment = require('moment');
 const logger = require('winston');
 const IO = require('socket.io-client');
+const {expect} = require('chai');
 
 // Setup
 logger.level = 'error';
@@ -20,6 +21,7 @@ const ioConnect = token => new Promise((resolve) => {
   const io = IO(host, options);
   io.once('connect', () => resolve(io));
 });
+const ioDisconnect = client => Promise.resolve(client.disconnect());
 
 describe('Basic socketio tests', function () {
   const testUserId = '5825bb7afe7545132c88c761';
@@ -40,13 +42,21 @@ describe('Basic socketio tests', function () {
     return ioConnect(token);
   });
 
-  /* @todo
   describe('io queries', function () {
     let io;
     beforeEach(function () {
       return ioConnect(token)
-        .then((ser) => { io = ser; });
+        .then((client) => { io = client; });
+    });
+    afterEach(function () {
+      return ioDisconnect(io);
+    });
+    it('whoami', function (done) {
+      io.emit('whoami', (error, me) => {
+        expect(me).to.have.property('isAdmin');
+        expect(me).to.have.property('group');
+        done();
+      });
     });
   });
-  */
 });

--- a/test/tests_api/socketio.js
+++ b/test/tests_api/socketio.js
@@ -1,27 +1,49 @@
 /* eslint-disable func-names, prefer-arrow-callback, no-unused-expressions */
 
 // Third party components
+const _ = require('lodash');
 const jwtSimple = require('jwt-simple');
 const nconf = require('../../config');
 const moment = require('moment');
 const logger = require('winston');
 const IO = require('socket.io-client');
-const {expect} = require('chai');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 
+chai.use(chaiAsPromised);
+const {expect, assert} = chai;
 // Setup
 logger.level = 'error';
 
 // Test variables
 const host = 'http://localhost:3000';
 
-const ioConnect = token => new Promise((resolve) => {
+const ioConnect = token => new Promise((resolve, reject) => {
   const options = {
     query: `token=${token}`
   };
-  const io = IO(host, options);
-  io.once('connect', () => resolve(io));
+  const client = IO(host, options);
+
+  const _reject = (error) => {
+    client.disconnect();
+    reject(error);
+  };
+  client.once('connect', () => {
+    client.removeListener('connect_error', reject);
+    client.removeListener('connect_timeout', reject);
+    client.removeListener('error', reject);
+    resolve(client);
+  });
+  client.once('error', _reject);
+  client.once('connect_error', _reject);
+  client.once('connect_timeout', _reject);
 });
-const ioDisconnect = client => Promise.resolve(client.disconnect());
+const ioDisconnect = (client) => {
+  if (_.isObject(client)) {
+    return Promise.resolve(client.disconnect());
+  }
+  return Promise.resolve();
+};
 
 describe('Basic socketio tests', function () {
   const testUserId = '5825bb7afe7545132c88c761';
@@ -30,8 +52,8 @@ describe('Basic socketio tests', function () {
   before(function () {
     // Create token for requests
     const payload = {
-      sub: testUserId,
-      group: 'admins',
+      _id: testUserId,
+      groups: ['admins'],
       iat: moment().unix(),
       exp: moment().add(2, 'h').unix()
     };
@@ -39,7 +61,11 @@ describe('Basic socketio tests', function () {
   });
 
   it('connection works', function () {
-    return ioConnect(token);
+    return ioConnect(token)
+      .then(io => ioDisconnect((io)));
+  });
+  it('connection denied when invalid token', function () {
+    return assert.isRejected(ioConnect('invalid_token'), /jwt malformed/);
   });
 
   describe('io queries', function () {
@@ -54,7 +80,7 @@ describe('Basic socketio tests', function () {
     it('whoami', function (done) {
       io.emit('whoami', (error, me) => {
         expect(me).to.have.property('isAdmin');
-        expect(me).to.have.property('group');
+        expect(me).to.have.property('groups');
         done();
       });
     });


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
rework socketio step better - it will be more in use in future so this is prepare PR for it.
Now user have to use query token to use socketio connections (implemented in opentmi-jsclient).

This also brings simple `whoami` socketio API to give user related information from DB.
 
## Related PRs
#94 (extracted from here)

## Todos
- [x] Tests (API tests)
- [x] Documentation