### PR TITLE
revert find with type count back as a object like it was originally.

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -71,8 +71,7 @@ class DefaultController extends EventEmitter {
       if (error) {
         logger.warn(error);
         res.status(300).json({error: error.message});
-      }
-      else {
+      } else {
         this.emit('find', list);
         res.json(list);
       }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -67,15 +67,16 @@ class DefaultController extends EventEmitter {
   }
 
   find(req, res) {
-    this._model.leanQuery(req.query)
-      .then((list) => {
-        this.emit('find', list);
-        res.json(list);
-      })
-      .catch((error) => {
+    this._model.leanQuery(req.query, (error, list) => {
+      if (error) {
         logger.warn(error);
         res.status(300).json({error: error.message});
-      });
+      }
+      else {
+        this.emit('find', list);
+        res.json(list);
+      }
+    });
   }
 
   create(req, res) {

--- a/test/tests_api/results.js
+++ b/test/tests_api/results.js
@@ -52,6 +52,19 @@ describe('Results', function () {
     done();
   });
 
+  it('should get count as a object', function (done) {
+    superagent.get(`${api}/results?t=count`)
+      //.set('authorization', authString)
+      .type('json')
+      .end(function (error, res) {
+        expect(error).to.equal(null);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('count');
+        expect(res.body.count).to.be.an('number');
+        done();
+      });
+  });
+
   it('should return a single result on results/<id> GET', function (done) {
     const expectedBody = existingResultBody;
 

--- a/test/tests_api/results.js
+++ b/test/tests_api/results.js
@@ -54,7 +54,7 @@ describe('Results', function () {
 
   it('should get count as a object', function (done) {
     superagent.get(`${api}/results?t=count`)
-      //.set('authorization', authString)
+      .set('authorization', authString)
       .type('json')
       .end(function (error, res) {
         expect(error).to.equal(null);


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
revert find query to use callback because mongoose-query is not tested enough with promises.

#115 PR breaks this in first place (was landed to v0.5.0)
