### PR TITLE
Fix result uploading with duration when tcid contains invalid regular expression

### DIFF
--- a/app/models/testcase.js
+++ b/app/models/testcase.js
@@ -235,7 +235,7 @@ TestCaseSchema.method({
 
 TestCaseSchema.static({
   findByTcid(testcaseId, next) {
-    return this.findOne({tcid: new RegExp(testcaseId, 'i')}, next);
+    return this.findOne({tcid: testcaseId}, next);
   },
   updateTcDuration(testcaseId, duration) {
     this.findByTcid(testcaseId, (error, testcase) => {

--- a/test/tests_api/results.js
+++ b/test/tests_api/results.js
@@ -109,6 +109,23 @@ describe('Results', function () {
         done();
       });
   });
+  it('should accept POST with "++" in tcid', function (done) {
+    const requestBody = {
+      tcid: 'C++ heap',
+      exec: {
+        verdict: 'pass',
+        duration: 1
+      }
+    };
+    superagent.post(`${api}/results`)
+      .set('authorization', authString)
+      .send(requestBody)
+      .end((error, res) => {
+        expect(error).to.not.exist;
+        expect(res).to.have.property('status', 200);
+        done();
+      });
+  });
 
   it('should accept POST with log file that has no data', function (done) {
     const requestBody = JSON.parse(JSON.stringify(validResultBody));


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES | NO

## Description
duration was updated based on tcid as a RegEx but it also restrict to use certain regex related character combination like ++ which causes unexpected result upload failure (exception in backend). Use tcid directly as search term since regex is not needed.

## Related issues
Fixes: https://github.com/OpenTMI/opentmi-pyclient/issues/20

## Todos
- [x] Tests