### PR TITLE
upgrade node.js to 8.11.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/opentmi
     docker:
-      - image: circleci/node:6.11.4-browsers
+      - image: circleci/node:8.11.4-browsers
         environment:
           CHROME_BIN: "/usr/bin/google-chrome"
           NODE_ENV: test


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES, new recommended node.js version

## Description
Upgrade node.js to 8.11.4 in CI