### PR TITLE
fix express-winston logger wrapping

### DIFF
--- a/app/tools/logger.js
+++ b/app/tools/logger.js
@@ -80,7 +80,7 @@ class MasterLogger {
     }
   }
   log(level, ...args) {
-    if(typeof level == 'object') {
+    if (typeof level === 'object') {
       this.log(level.level, level.message, level.meta);
       return;
     }
@@ -131,7 +131,7 @@ class WorkerLogger {
   }
 
   log(level, ...args) {
-    if(typeof level == 'object') {
+    if (typeof level === 'object') {
       this.log(level.level, level.message, level.meta);
       return;
     }

--- a/app/tools/logger.js
+++ b/app/tools/logger.js
@@ -80,6 +80,10 @@ class MasterLogger {
     }
   }
   log(level, ...args) {
+    if(typeof level == 'object') {
+      this.log(level.level, level.message, level.meta);
+      return;
+    }
     const data = args || [''];
     data[0] = `<Master> ${data[0]}`;
     this.logger.log(level, ...data);
@@ -127,6 +131,10 @@ class WorkerLogger {
   }
 
   log(level, ...args) {
+    if(typeof level == 'object') {
+      this.log(level.level, level.message, level.meta);
+      return;
+    }
     this._proxy(level, ...args);
   }
   error(...args) {


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES: touch master `MasterLogger` -implementation. Should work still without master update because WorkerLogger manage conversion also.

## Description
winston-express calls logger.log with `{level, message, meta}` instead of `level, message, meta` causing unexpected exception
