### PR TITLE
use fs.copySync instead - copyFileSync does not exists until node 8.x

### DIFF
--- a/app/tools/config.js
+++ b/app/tools/config.js
@@ -67,7 +67,7 @@ nconf
 
 const cfgFileName = path.resolve(process.cwd(), nconf.get('config'));
 if (!fs.existsSync(cfgFileName)) {
-  fs.copyFileSync(sampleFile, cfgFileName);
+  fs.copySync(sampleFile, cfgFileName);
 }
 
 module.exports = nconf;


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
#200 causes unexpected exception in node.js 6.x when config.json does not exists - because fs.copyFileSync coming in node.js 8.x. Switches to use fs.copySync instead.