### PR TITLE
add password recovery mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Available [here](doc/APIs)
 
 By default opentmi is started as development mode. You can configure environment using [`--config <file>`](`config.example.json`) -option.
 
-note: `"mongo"` options overwrites defaults and is pypassed to [MongoClient](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html).
+**note**: 
+* `"mongo"` options overwrites defaults and is pypassed to [MongoClient](http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html).
+* `"smtp"` options is pypassed to [nodemailer](https://nodemailer.com/smtp/) transport configurations. To activate smpt use `enabled` property.
 
 # Architecture
 

--- a/app/controllers/emailer.js
+++ b/app/controllers/emailer.js
@@ -7,50 +7,51 @@ const logger = require('../tools/logger');
 
 let emailer = {send: () => Promise.reject('emailer is not configured')};
 
+
 class Emailer {
-    constructor(config) {
-        this._smtpTransport = _.get(config, 'enabled') ?
-            this._initialize(config) : Emailer.getDummyTransport();
-        emailer = this;
-    }
-    static getDummyTransport() {
-        return {
-            verify: () => Promise.resolve(),
-            sendMail: () => Promise.reject('smtp is not configured to server')
+  constructor(config) {
+    this._smtpTransport = _.get(config, 'enabled') ?
+      Emailer._initialize(config) : Emailer.getDummyTransport();
+    emailer = this;
+  }
+  static getDummyTransport() {
+    return {
+      verify: () => Promise.resolve(),
+      sendMail: () => Promise.reject('smtp is not configured to server')
+    };
+  }
+  static _initialize(config) {
+    const mailerConfig = _.defaults(config, {
+      host: 'smtp.gmail.com',
+      port: 25,
+      secure: false,
+      connectionTimeout: 5000,
+      tls: {
+        rejectUnauthorized: false
+      }
+    });
+    return nodemailer.createTransport(mailerConfig);
+  }
+  verify() {
+    return this._smtpTransport.verify()
+      .then((value) => {
+        if (value === undefined) {
+          return;
         }
-    }
-    _initialize(config) {
-        const mailerConfig = _.defaults(config, {
-            host: 'smtp.gmail.com',
-            port: 25,
-            secure: false,
-            connectionTimeout: 5000,
-            tls: {
-                rejectUnauthorized: false
-            }
-        });
-        return nodemailer.createTransport(mailerConfig);
-    }
-    verify() {
-        return this._smtpTransport.verify()
-            .then((value) => {
-               if (value === undefined) {
-                   return;
-               }
-               logger.debug('smtp verified - ok');
-            });
-    }
-    static send(data) {
-        return emailer.send(data);
-    }
-    send({to, from = 'admin@opentmi.com', subject, text}) {
-        const mailOptions = {to, from, subject, text};
-        console.log(mailOptions);
-        return this._smtpTransport.sendMail(mailOptions)
-            .then(() => {
-                logger.info(`Sent email to "${to}" with subject: "${subject}"`);
-            });
-    }
+        logger.debug('smtp verified - ok');
+      });
+  }
+  static send(data) {
+    return emailer.send(data);
+  }
+  send({to, from = 'admin@opentmi.com', subject, text}) {
+    const mailOptions = {to, from, subject, text};
+    logger.silly(mailOptions);
+    return this._smtpTransport.sendMail(mailOptions)
+      .then(() => {
+        logger.info(`Sent email to "${to}" with subject: "${subject}"`);
+      });
+  }
 }
 
 module.exports = Emailer;

--- a/app/controllers/emailer.js
+++ b/app/controllers/emailer.js
@@ -11,13 +11,14 @@ let emailer = {send: () => Promise.reject('emailer is not configured')};
 class Emailer {
   constructor(config) {
     this._smtpTransport = _.get(config, 'enabled') ?
-      Emailer._initialize(config) : Emailer.getDummyTransport();
+      Emailer._initialize(_.omit(config, ['enabled'])) : Emailer.getDummyTransport();
     emailer = this;
   }
   static getDummyTransport() {
+    logger.info('smtp is not configured, cannot send emails');
     return {
       verify: () => Promise.resolve(),
-      sendMail: () => Promise.reject('smtp is not configured to server')
+      sendMail: () => Promise.reject(new Error('smtp is not configured to server'))
     };
   }
   static _initialize(config) {
@@ -46,7 +47,7 @@ class Emailer {
   }
   send({to, from = 'admin@opentmi.com', subject, text}) {
     const mailOptions = {to, from, subject, text};
-    logger.silly(mailOptions);
+    logger.silly(`sending mail: ${JSON.stringify(mailOptions)}`);
     return this._smtpTransport.sendMail(mailOptions)
       .then(() => {
         logger.info(`Sent email to "${to}" with subject: "${subject}"`);

--- a/app/controllers/emailer.js
+++ b/app/controllers/emailer.js
@@ -1,0 +1,56 @@
+// 3rd party modules
+const _ = require('lodash');
+const nodemailer = require('nodemailer');
+// internal modules
+const logger = require('../tools/logger');
+
+
+let emailer = {send: () => Promise.reject('emailer is not configured')};
+
+class Emailer {
+    constructor(config) {
+        this._smtpTransport = _.get(config, 'enabled') ?
+            this._initialize(config) : Emailer.getDummyTransport();
+        emailer = this;
+    }
+    static getDummyTransport() {
+        return {
+            verify: () => Promise.resolve(),
+            sendMail: () => Promise.reject('smtp is not configured to server')
+        }
+    }
+    _initialize(config) {
+        const mailerConfig = _.defaults(config, {
+            host: 'smtp.gmail.com',
+            port: 25,
+            secure: false,
+            connectionTimeout: 5000,
+            tls: {
+                rejectUnauthorized: false
+            }
+        });
+        return nodemailer.createTransport(mailerConfig);
+    }
+    verify() {
+        return this._smtpTransport.verify()
+            .then((value) => {
+               if (value === undefined) {
+                   return;
+               }
+               logger.debug('smtp verified - ok');
+            });
+    }
+    static send(data) {
+        return emailer.send(data);
+    }
+    send({to, from = 'admin@opentmi.com', subject, text}) {
+        const mailOptions = {to, from, subject, text};
+        console.log(mailOptions);
+        return this._smtpTransport.sendMail(mailOptions)
+            .then(() => {
+                logger.info(`Sent email to "${to}" with subject: "${subject}"`);
+            });
+    }
+}
+
+module.exports = Emailer;

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -71,80 +71,81 @@ class UsersController extends DefaultController {
   }
   forgotPassword(req, res) {
     return Promise
-        .try(() => {
-          const email = req.body.email;
-          if (!email) {
-            const error = new Error('missing email address');
-            error.code = 400;
-            throw error;
-          }
-          return email;
-        })
-        .then((email) => {
-          return this.Model.findOne({email});
-        })
-        .then((user) => {
-          if (!user) {
-            const error = new Error('email not exists');
-            error.code = 400;
-            throw error;
-          }
-          user.resetPasswordToken = crypto.randomBytes(20).toString('hex');
-          user.resetPasswordExpires = moment().add(1, 'hours').toDate(); // 1 h
-          return user.save();
-        })
-        .then((user) => {
-            logger.debug(`User ${user.name} password reset token are: ${user.resetPasswordToken}`);
-            return this._notifyPasswordToken(user);
-        })
-        .then(() => res.status(200).json({message: 'password reset token is sent to you'}))
-        .catch(UsersController._restCatch.bind(res));
+      .try(() => {
+        const email = req.body.email;
+        if (!email) {
+          const error = new Error('missing email address');
+          error.code = 400;
+          throw error;
+        }
+        return email;
+      })
+      .then(email => this.Model.findOne({email}))
+      .then((theUser) => {
+        const user = theUser;
+        if (!user) {
+          const error = new Error('email not exists');
+          error.code = 400;
+          throw error;
+        }
+        user.resetPasswordToken = crypto.randomBytes(20).toString('hex');
+        user.resetPasswordExpires = moment().add(1, 'hours').toDate(); // 1 h
+        return user.save();
+      })
+      .then((user) => {
+        logger.debug(`User ${user.name} password reset token are: ${user.resetPasswordToken}`);
+        return UsersController._notifyPasswordToken(user);
+      })
+      .then(() => res.status(200).json({message: 'password reset token is sent to you'}))
+      .catch(UsersController._restCatch.bind(res));
   }
-  _notifyPasswordToken(user) {
-      const token = user.resetPasswordToken;
-      const subject = 'OpenTMI Password Change';
-      const host = 'opentmi.com';
-      const link = `https://${host}/change-password/${token}`; // @todo this should be configurable
-      const text = UsersController._tokenEmail(link, user.email, token);
-      return Emailer.send({to: user.email, subject, text});
+  static _notifyPasswordToken(user) {
+    const token = user.resetPasswordToken;
+    const subject = 'OpenTMI Password Change';
+    const host = 'opentmi.com';
+    const link = `https://${host}/change-password/${token}`; // @todo this should be configurable
+    const text = UsersController._tokenEmail(link, user.email, token);
+    return Emailer.send({to: user.email, subject, text});
   }
   static _tokenEmail(link, email, token) {
-      return `You requested a password reset for your OpenTMI account.` +
+    return 'You requested a password reset for your OpenTMI account.' +
              'In case this request was not initiated by you, you can safely ignore it.\n\n' +
              'Your account:\n' +
              `Email address: ${email}\n` +
              'To reset your password, please click on the link below:\n' +
-             `${link}\n`;
-    }
+             `${link}\n` +
+             `Or using token: ${token}`;
+  }
   changePassword(req, res) {
     return Promise
-        .try(() => {
-          if (!_.has(req, 'body.password')) {
-            const error = new Error('Missing new password');
-            error.code = 400;
-            throw error;
-          }
-        })
-        .then(() => this.Model.findOne({
-            resetPasswordToken: req.body.token,
-            resetPasswordExpires: { $gt: Date.now() }
-          }
-        ))
-        .then((user) => {
-          if (!user) {
-            const error = new Error('invalid or expired token');
-            error.code = 401;
-            throw error;
-          }
-          user.password = req.body.password;
-          user.resetPasswordToken = undefined;
-          user.resetPasswordExpires = undefined;
-          return user.save();
-        })
-        .then(() => {
-          res.status(200).json({message: 'password reset was successful'});
-        })
-        .catch(UsersController._restCatch.bind(res));
+      .try(() => {
+        if (!_.has(req, 'body.password')) {
+          const error = new Error('Missing new password');
+          error.code = 400;
+          throw error;
+        }
+      })
+      .then(() => this.Model.findOne({
+        resetPasswordToken: req.body.token,
+        resetPasswordExpires: {$gt: Date.now()}
+      }
+      ))
+      .then((theUser) => {
+        const user = theUser;
+        if (!user) {
+          const error = new Error('invalid or expired token');
+          error.code = 401;
+          throw error;
+        }
+        user.password = req.body.password;
+        user.resetPasswordToken = undefined;
+        user.resetPasswordExpires = undefined;
+        return user.save();
+      })
+      .then(() => {
+        res.status(200).json({message: 'password reset was successful'});
+      })
+      .catch(UsersController._restCatch.bind(res));
   }
   static _restCatch(error) {
     this.status(error.code || 500).json({message: error.message, stack: error.stack});

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -9,6 +9,7 @@ const moment = require('moment');
 const Promise = require('bluebird');
 
 // Own modules
+const config = require('../tools/config');
 const Emailer = require('./emailer');
 const logger = require('../tools/logger');
 const DefaultController = require('./');
@@ -102,8 +103,8 @@ class UsersController extends DefaultController {
   static _notifyPasswordToken(user) {
     const token = user.resetPasswordToken;
     const subject = 'OpenTMI Password Change';
-    const host = 'opentmi.com';
-    const link = `https://${host}/change-password/${token}`; // @todo this should be configurable
+    const host = _.get(config.get('github'), 'callbackURL', 'https://opentmi');
+    const link = `${host}/change-password/${token}`;
     const text = UsersController._tokenEmail(link, user.email, token);
     return Emailer.send({to: user.email, subject, text});
   }
@@ -152,6 +153,8 @@ class UsersController extends DefaultController {
     const body = {message: error.message};
     if (process.env.NODE_ENV !== 'production') {
       body.stack = error.stack;
+      logger.error(error);
+      logger.error(error.stack);
     }
     this.status(error.code || 500).json(body);
   }

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -119,8 +119,9 @@ class UsersController extends DefaultController {
   changePassword(req, res) {
     return Promise
       .try(() => {
-        if (!_.has(req, 'body.password')) {
-          const error = new Error('Missing new password');
+        if (!_.has(req, 'body.password') ||
+            !_.has(req, 'body.token')) {
+          const error = new Error('Missing token or new password');
           error.code = 400;
           throw error;
         }
@@ -148,7 +149,11 @@ class UsersController extends DefaultController {
       .catch(UsersController._restCatch.bind(res));
   }
   static _restCatch(error) {
-    this.status(error.code || 500).json({message: error.message, stack: error.stack});
+    const body = {message: error.message};
+    if (process.env.NODE_ENV !== 'production') {
+      body.stack = error.stack;
+    }
+    this.status(error.code || 500).json(body);
   }
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -11,6 +11,7 @@ const express = require('./express');
 const Server = require('./server');
 const models = require('./models');
 const routes = require('./routes');
+const Emailer = require('./controllers/emailer');
 const AddonManager = require('./addons');
 const logger = require('./tools/logger');
 const config = require('./tools/config');
@@ -43,12 +44,15 @@ const io = SocketIO(server);
 const ioAdapter = mongoAdapter(dbUrl);
 io.adapter(ioAdapter);
 
+const emailer = new Emailer(config.get('smtp'));
+
 // Initialize database connection
 DB.connect()
   .catch((error) => {
     console.error('mongoDB connection failed: ', error.stack); // eslint-disable-line no-console
     process.exit(-1);
   })
+  .then(() => emailer.verify())
   .then(() => models.registerModels())
   .then(() => express(app))
   .then(() => routes.registerRoutes(app, io))

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -31,6 +31,11 @@ const UserSchema = new Schema({
   name: {type: String, required: true},
   email: {type: String, unique: true, sparse: true, lowercase: true},
   password: {type: String, select: false},
+
+  // for recovering
+  resetPasswordToken: {type: String},
+  resetPasswordExpires: {type: Date},
+
   displayName: String,
   picture: String,
   bitbucket: String,

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -84,6 +84,11 @@ function Route(app) {
   userRouter.use('/:User', singleUserRouter);
   app.use('/api/v0/users', userRouter);
 
+  // password recovery
+  app.post('/api/v0/password/forgot', userController.forgotPassword.bind(userController));
+  app.post('/api/v0/password/change', userController.changePassword.bind(userController));
+
+
   const authRoute = express.Router();
   authRoute
     .post('/login', passport.authenticate('local'),

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,16 @@
     "user": "admin",
     "pwd": "admin"
   },
+  "smtp": {
+    "enabled": false,
+    "host": "smtp.gmail.com",
+    "port": 465,
+    "secure": true,
+    "auth": {
+        "user": "<username>",
+        "pass": "<password>"
+    }
+  },
   "mongo": {
     "sslValidate": true
   },

--- a/doc/APIs/user.md
+++ b/doc/APIs/user.md
@@ -126,3 +126,64 @@ GET /api/v0/users/:User/apikeys/new
 ```
 DELETE /api/v0/users/:User/apikeys/:Key
 ```  
+
+
+## recover forgot password
+
+To request recovery token to user email
+
+* ##### URL
+  /api/v0/password/forgot
+
+* ##### Method:  
+  `POST`
+
+* ##### Request:  
+    **Content:**  
+    ```json
+    { "email": "my-email@address.com" }
+    ```
+
+* ##### Success Response:
+  * **Code:** 200  
+    **Content:**  
+    ```json
+    { "message": "success" }
+    ```
+
+* ##### Error Response:
+  * **Code:** 400 UNAUTHORIZED  
+    **Content:**  
+    ```json
+    { "message": "No authorization token was found" }
+    ```
+    
+## change password using recovery token
+
+To change password using token that was send when previous API was used.
+
+* ##### URL
+  /api/v0/password/change
+
+* ##### Method:  
+  `POST`
+
+* ##### Request:  
+    **Content:**  
+    ```json
+    { "token": "<token>", "password":  "<new-password>" }
+    ```
+
+* ##### Success Response:
+  * **Code:** 200  
+    **Content:**  
+    ```json
+    { "message": "success" }
+    ```
+
+* ##### Error Response:
+  * **Code:** 400 UNAUTHORIZED  
+    **Content:**  
+    ```json
+    { "message": "<message>" }
+    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,7 +231,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -754,7 +754,7 @@
     "chai-as-promised": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
       "dev": true,
       "requires": {
         "check-error": "^1.0.2"
@@ -832,7 +832,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "class-utils": {
@@ -1519,7 +1519,7 @@
     "emoji-regex": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "integrity": "sha1-m66pKbFVVlwR6kHGYm6qZc75ksI=",
       "dev": true
     },
     "enabled": {
@@ -1815,7 +1815,7 @@
     "eslint-config-airbnb": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-15.1.0.tgz",
-      "integrity": "sha512-m0q9fiMBzDAIbirlGnpJNWToIhdhJmXXnMG+IFflYzzod9231ZhtmGKegKg8E9T8F1YuVaDSU1FnCm5b9iXVhQ==",
+      "integrity": "sha1-/UMpZakG4wE5ABuoMPWPc67dro4=",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^11.3.0"
@@ -2093,7 +2093,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "~1.3.5",
@@ -3167,7 +3167,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -3312,7 +3312,7 @@
     "grunt-exec": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-3.0.0.tgz",
-      "integrity": "sha512-cgAlreXf3muSYS5LzW0Cc4xHK03BjFOYk0MqCQ/MZ3k1Xz2GU7D+IAJg4UKicxpO+XdONJdx/NJ6kpy2wI+uHg==",
+      "integrity": "sha1-iB+GjWQJh4j92vIvol2FcqnWTcc=",
       "dev": true
     },
     "grunt-express-server": {
@@ -3706,7 +3706,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -4643,7 +4643,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5160,6 +5160,11 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "nodemailer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-5.1.1.tgz",
+      "integrity": "sha512-hKGCoeNdFL2W7S76J/Oucbw0/qRlfG815tENdhzcqTpSjKgAN91mFOqU2lQUflRRxFM7iZvCyaFcAR9noc/CqQ=="
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -6879,7 +6884,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mongoose-query": "^0.5.3",
     "mongoose-schema-jsonschema": "1.2.1",
     "nconf": "^0.10.0",
+    "nodemailer": "^5.1.1",
     "opentmi-addon": "github:opentmi/opentmi-addon",
     "passport": "^0.4.0",
     "passport-github-token": "^2.1.0",

--- a/test/unittests/controller/users.js
+++ b/test/unittests/controller/users.js
@@ -27,11 +27,11 @@ describe('controllers/users', function () {
 
     beforeEach(function () {
       controller = new UsersController();
-      sinon.stub(controller, '_notifyPasswordToken').resolves();
+      sinon.stub(UsersController, '_notifyPasswordToken').resolves();
       res = newResponse();
     });
     afterEach(function () {
-        controller._notifyPasswordToken.restore();
+      UsersController._notifyPasswordToken.restore();
     });
     it('ok', function () {
       expect(controller).to.exist;
@@ -130,97 +130,97 @@ describe('controllers/users', function () {
       });
     });
     describe('password', function () {
-        it('forgotPassword', function () {
-            const req = newRequest({email: 'my@mail.com'}, {});
-            req.user = {update: sinon.stub()};
-            const resetPasswordToken = sinon.stub();
-            const resetPasswordExpires = sinon.stub();
-            const user = {
-                save: sinon.stub().resolves(this),
-                set resetPasswordToken(value) { resetPasswordToken(value); },
-                set resetPasswordExpires(value) { resetPasswordExpires(value); }
-            };
-            controller.Model.findOne = sinon.stub().resolves(user);
-            return controller.forgotPassword(req, res)
-                .then(() => {
-                    expect(controller.Model.findOne.calledOnceWith({email: 'my@mail.com'})).to.be.true;
-                    expect(resetPasswordToken.getCall(0).args[0]).to.be.an('string');
-                    expect(resetPasswordExpires.getCall(0).args[0]).to.be.an('date');
-                    expect(user.save.calledOnce).to.be.true;
-                    expect(controller._notifyPasswordToken.calledOnce).to.be.true;
-                    expect(res.status.calledOnceWith(200)).to.be.true;
-                    expect(res.json.getCall(0).args[0]).to.be.an('object');
-                });
-        });
-        it('forgotPassword invalid email', function () {
-            const req = newRequest({email: 'my@mail.com'}, {});
-            req.user = {update: sinon.stub()};
-            const resetPasswordToken = sinon.stub();
-            const resetPasswordExpires = sinon.stub();
-            const user = {
-                save: sinon.stub().resolves(this),
-                set resetPasswordToken(value) { resetPasswordToken(value); },
-                set resetPasswordExpires(value) { resetPasswordExpires(value); }
-            };
-            controller.Model.findOne = sinon.stub().resolves();
-            return controller.forgotPassword(req, res)
-                .then(() => {
-                    expect(controller.Model.findOne.calledOnceWith({email: 'my@mail.com'})).to.be.true;
-                    expect(resetPasswordToken.called).to.be.false;
-                    expect(resetPasswordExpires.called).to.be.false;
-                    expect(user.save.called).to.be.false;
-                    expect(controller._notifyPasswordToken.calledOnce).to.be.false;
-                    expect(res.status.calledOnceWith(400)).to.be.true;
-                    expect(res.json.getCall(0).args[0]).to.be.an('object');
-                });
-        });
-        it('forgotPassword email not exists', function () {
-            const req = newRequest({}, {});
-            req.user = {update: sinon.stub()};
-            const resetPasswordToken = sinon.stub();
-            const resetPasswordExpires = sinon.stub();
-            const user = {
-                save: sinon.stub().resolves(this),
-                set resetPasswordToken(value) { resetPasswordToken(value); },
-                set resetPasswordExpires(value) { resetPasswordExpires(value); }
-            };
-            controller.Model.findOne = sinon.stub().resolves();
-            return controller.forgotPassword(req, res)
-                .then(() => {
-                    expect(controller.Model.findOne.called).to.be.false;
-                    expect(resetPasswordToken.called).to.be.false;
-                    expect(resetPasswordExpires.called).to.be.false;
-                    expect(controller._notifyPasswordToken.calledOnce).to.be.false;
-                    expect(user.save.called).to.be.false;
-                    expect(res.status.calledOnceWith(400)).to.be.true;
-                    expect(res.json.getCall(0).args[0]).to.be.an('object');
-                });
-        });
-        it('resetPassword', function () {
-            const reqForget = newRequest({email: 'my@mail.com'}, {});
-            reqForget.user = {update: sinon.stub()};
-            const resetPasswordToken = sinon.stub();
-            const resetPasswordExpires = sinon.stub();
-            const resChange = newResponse();
-            const user = {
-                save: sinon.stub().resolves(this),
-                set resetPasswordToken(value) { resetPasswordToken(value); },
-                set resetPasswordExpires(value) { resetPasswordExpires(value); }
-            };
-            controller.Model.findOne = sinon.stub().resolves(user);
-            return controller.forgotPassword(reqForget, res)
-                .then(() => {
-                    const token = resetPasswordToken.getCall(0).args[0];
-                    const reqChange = newRequest({token, password: 'newPass'});
-                    user.save.reset();
-                    return controller.changePassword(reqChange, resChange);
-                })
-                .then(() => {
-                    expect(user.save.callCount).to.be.equal(1);
-                    expect(res.status.calledOnceWith(200)).to.be.true;
-                    expect(res.json.getCall(0).args[0]).to.be.an('object');
-                });
-        });
+      it('forgotPassword', function () {
+        const req = newRequest({email: 'my@mail.com'}, {});
+        req.user = {update: sinon.stub()};
+        const resetPasswordToken = sinon.stub();
+        const resetPasswordExpires = sinon.stub();
+        const user = {
+          save: sinon.stub().resolves(this),
+          set resetPasswordToken(value) { resetPasswordToken(value); },
+          set resetPasswordExpires(value) { resetPasswordExpires(value); }
+        };
+        controller.Model.findOne = sinon.stub().resolves(user);
+        return controller.forgotPassword(req, res)
+          .then(() => {
+            expect(controller.Model.findOne.calledOnceWith({email: 'my@mail.com'})).to.be.true;
+            expect(resetPasswordToken.getCall(0).args[0]).to.be.an('string');
+            expect(resetPasswordExpires.getCall(0).args[0]).to.be.an('date');
+            expect(user.save.calledOnce).to.be.true;
+            expect(UsersController._notifyPasswordToken.calledOnce).to.be.true;
+            expect(res.status.calledOnceWith(200)).to.be.true;
+            expect(res.json.getCall(0).args[0]).to.be.an('object');
+          });
+      });
+      it('forgotPassword invalid email', function () {
+        const req = newRequest({email: 'my@mail.com'}, {});
+        req.user = {update: sinon.stub()};
+        const resetPasswordToken = sinon.stub();
+        const resetPasswordExpires = sinon.stub();
+        const user = {
+          save: sinon.stub().resolves(this),
+          set resetPasswordToken(value) { resetPasswordToken(value); },
+          set resetPasswordExpires(value) { resetPasswordExpires(value); }
+        };
+        controller.Model.findOne = sinon.stub().resolves();
+        return controller.forgotPassword(req, res)
+          .then(() => {
+            expect(controller.Model.findOne.calledOnceWith({email: 'my@mail.com'})).to.be.true;
+            expect(resetPasswordToken.called).to.be.false;
+            expect(resetPasswordExpires.called).to.be.false;
+            expect(user.save.called).to.be.false;
+            expect(UsersController._notifyPasswordToken.calledOnce).to.be.false;
+            expect(res.status.calledOnceWith(400)).to.be.true;
+            expect(res.json.getCall(0).args[0]).to.be.an('object');
+          });
+      });
+      it('forgotPassword email not exists', function () {
+        const req = newRequest({}, {});
+        req.user = {update: sinon.stub()};
+        const resetPasswordToken = sinon.stub();
+        const resetPasswordExpires = sinon.stub();
+        const user = {
+          save: sinon.stub().resolves(this),
+          set resetPasswordToken(value) { resetPasswordToken(value); },
+          set resetPasswordExpires(value) { resetPasswordExpires(value); }
+        };
+        controller.Model.findOne = sinon.stub().resolves();
+        return controller.forgotPassword(req, res)
+          .then(() => {
+            expect(controller.Model.findOne.called).to.be.false;
+            expect(resetPasswordToken.called).to.be.false;
+            expect(resetPasswordExpires.called).to.be.false;
+            expect(UsersController._notifyPasswordToken.calledOnce).to.be.false;
+            expect(user.save.called).to.be.false;
+            expect(res.status.calledOnceWith(400)).to.be.true;
+            expect(res.json.getCall(0).args[0]).to.be.an('object');
+          });
+      });
+      it('resetPassword', function () {
+        const reqForget = newRequest({email: 'my@mail.com'}, {});
+        reqForget.user = {update: sinon.stub()};
+        const resetPasswordToken = sinon.stub();
+        const resetPasswordExpires = sinon.stub();
+        const resChange = newResponse();
+        const user = {
+          save: sinon.stub().resolves(this),
+          set resetPasswordToken(value) { resetPasswordToken(value); },
+          set resetPasswordExpires(value) { resetPasswordExpires(value); }
+        };
+        controller.Model.findOne = sinon.stub().resolves(user);
+        return controller.forgotPassword(reqForget, res)
+          .then(() => {
+            const token = resetPasswordToken.getCall(0).args[0];
+            const reqChange = newRequest({token, password: 'newPass'});
+            user.save.reset();
+            return controller.changePassword(reqChange, resChange);
+          })
+          .then(() => {
+            expect(user.save.callCount).to.be.equal(1);
+            expect(res.status.calledOnceWith(200)).to.be.true;
+            expect(res.json.getCall(0).args[0]).to.be.an('object');
+          });
+      });
     });
   });
   describe('model', function () {

--- a/test/unittests/controller/users.js
+++ b/test/unittests/controller/users.js
@@ -196,7 +196,7 @@ describe('controllers/users', function () {
             expect(res.json.getCall(0).args[0]).to.be.an('object');
           });
       });
-      it('resetPassword', function () {
+      it('changePassword', function () {
         const reqForget = newRequest({email: 'my@mail.com'}, {});
         reqForget.user = {update: sinon.stub()};
         const resetPasswordToken = sinon.stub();
@@ -218,6 +218,55 @@ describe('controllers/users', function () {
           .then(() => {
             expect(user.save.callCount).to.be.equal(1);
             expect(res.status.calledOnceWith(200)).to.be.true;
+            expect(res.json.getCall(0).args[0]).to.be.an('object');
+          });
+      });
+
+      it('changePassword with invalid token', function () {
+        const reqForget = newRequest({email: 'my@mail.com'}, {});
+        reqForget.user = {update: sinon.stub()};
+        const resetPasswordToken = sinon.stub();
+        const resetPasswordExpires = sinon.stub();
+        const resChange = newResponse();
+        const user = {
+          save: sinon.stub().resolves(this),
+          set resetPasswordToken(value) { resetPasswordToken(value); },
+          set resetPasswordExpires(value) { resetPasswordExpires(value); }
+        };
+        controller.Model.findOne = sinon.stub().resolves();
+        return controller.forgotPassword(reqForget, res)
+          .then(() => {
+            const reqChange = newRequest({token: '123', password: 'newPass'});
+            user.save.reset();
+            return controller.changePassword(reqChange, resChange);
+          })
+          .then(() => {
+            expect(user.save.callCount).to.be.equal(0);
+            expect(res.status.calledOnceWith(400)).to.be.true;
+            expect(res.json.getCall(0).args[0]).to.be.an('object');
+          });
+      });
+      it('changePassword without token', function () {
+        const reqForget = newRequest({email: 'my@mail.com'}, {});
+        reqForget.user = {update: sinon.stub()};
+        const resetPasswordToken = sinon.stub();
+        const resetPasswordExpires = sinon.stub();
+        const resChange = newResponse();
+        const user = {
+          save: sinon.stub().resolves(this),
+          set resetPasswordToken(value) { resetPasswordToken(value); },
+          set resetPasswordExpires(value) { resetPasswordExpires(value); }
+        };
+        controller.Model.findOne = sinon.stub().resolves();
+        return controller.forgotPassword(reqForget, res)
+          .then(() => {
+            const reqChange = newRequest({password: 'newPass'});
+            user.save.reset();
+            return controller.changePassword(reqChange, resChange);
+          })
+          .then(() => {
+            expect(user.save.callCount).to.be.equal(0);
+            expect(res.status.calledOnceWith(400)).to.be.true;
             expect(res.json.getCall(0).args[0]).to.be.an('object');
           });
       });


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description

added 2 more APIs' for recover user email address
```
POST /api/v0/password/forgot  (payload: {email: <email>})
POST /api/v0/password/change (payload {token: <token>, password: <new-password>})
```

require smtp configurations to `config.json` as `"smtp"` keyword. configurations are bypassed to https://nodemailer.com/smtp/ transport configurations. See example configuration from [`config.example.json`](https://github.com/OpenTMI/opentmi/blob/master/config.example.json).

## Todos
- [x] Tests
- [x] Documentation