### PR TITLE
update mongoose-query to ^v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4856,60 +4856,14 @@
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mongoose-query": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mongoose-query/-/mongoose-query-0.5.3.tgz",
-      "integrity": "sha512-23FmYxZhZdYhb06ijzTZcOwMaFFkDztgM/9mn+MODagicfRWOWdlvX9ZVoaDPGzWsSp7wUOdxf8W+hknQ27Pwg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/mongoose-query/-/mongoose-query-0.6.0.tgz",
+      "integrity": "sha512-B2dgFw1Rr2iqcguYyIzy0DAYZ1OECrcUqVkPPfATCZlxVkIZwek+P3NtyRYHtF/B8RAZOyqd8f28Rdw+4SxYCA==",
       "requires": {
         "flat": "*",
         "lodash": ">=4.17.9",
         "moment": "^2.22.1",
-        "mongoose": "^5.2.2"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-          "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
-        },
-        "mongodb": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.10.tgz",
-          "integrity": "sha512-Uml42GeFxhTGQVml1XQ4cD0o/rp7J2ROy0fdYUcVitoE7vFqEhKH4TYVqRDpQr/bXtCJVxJdNQC1ntRxNREkPQ==",
-          "requires": {
-            "mongodb-core": "3.1.9",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "mongodb-core": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.9.tgz",
-          "integrity": "sha512-MJpciDABXMchrZphh3vMcqu8hkNf/Mi+Gk6btOimVg1XMxLXh87j6FAvRm+KmwD1A9fpu3qRQYcbQe4egj23og==",
-          "requires": {
-            "bson": "^1.1.0",
-            "require_optional": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
-        },
-        "mongoose": {
-          "version": "5.4.4",
-          "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.4.tgz",
-          "integrity": "sha512-KoYUFtgrXQ9Sxuf5IEE0Y2LswWGhHiN27bxtObANxMgXbuNLTtLB3xaep8jITUDitG4kkI+FKElUJH4uY8G2Bw==",
-          "requires": {
-            "async": "2.6.1",
-            "bson": "~1.1.0",
-            "kareem": "2.3.0",
-            "mongodb": "3.1.10",
-            "mongodb-core": "3.1.9",
-            "mongoose-legacy-pluralize": "1.0.2",
-            "mpath": "0.5.1",
-            "mquery": "3.2.0",
-            "ms": "2.0.0",
-            "regexp-clone": "0.0.1",
-            "safe-buffer": "5.1.2",
-            "sliced": "1.0.1"
-          }
-        }
+        "mongoose": "^5.2.14"
       }
     },
     "mongoose-schema-jsonschema": {
@@ -6887,7 +6841,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mime": "^2.4.0",
     "moment": "^2.24.0",
     "mongoose": "^5.4.7",
-    "mongoose-query": "^0.5.3",
+    "mongoose-query": "^0.6.0",
     "mongoose-schema-jsonschema": "1.2.1",
     "nconf": "^0.10.0",
     "nodemailer": "^5.1.1",


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This fixes mapReduce and allows to use more options for queries, like `to` (timeout).