### PR TITLE
Consolidate document id field

### DIFF
--- a/app/controllers/resources.js
+++ b/app/controllers/resources.js
@@ -23,7 +23,7 @@ class ResourcesController extends DefaultController {
     const find = {$or: []};
     const _id = req.params[this.modelName];
     if (DefaultController.isObjectId(_id)) {
-      find.$or.push({[this.docId]: _id});
+      find.$or.push({_id});
     }
     find.$or.push({'hw.sn': _id});
     return find;

--- a/app/models/resource.js
+++ b/app/models/resource.js
@@ -209,23 +209,16 @@ const ResourceSchema = new Schema({
   // Parent Resource
   parent: {type: ObjectId, ref: 'Resource'}
 });
+
+ResourceSchema.virtual('id').get(function getId() {
+  return this._id;
+});
 ResourceSchema.set('toJSON', {
   virtuals: true,
   getters: true,
   minimize: true,
   transform: (doc, ret) => {
-    const jsonResource = ret;
-
-    if (!jsonResource.id) {
-      jsonResource.id = ret._id;
-    }
-    delete jsonResource._id;
-
-    const ip = jsonResource.ip;
-    if (ip && ip.remote_connection && ip.remote_connection.authentication) {
-      delete ip.remote_connection.authentication;
-    }
-
+    _.unset(ret, 'ip.remote_connection.authentication');
     return ret;
   }
 });

--- a/app/models/resource.js
+++ b/app/models/resource.js
@@ -210,9 +210,6 @@ const ResourceSchema = new Schema({
   parent: {type: ObjectId, ref: 'Resource'}
 });
 
-ResourceSchema.virtual('id').get(function getId() {
-  return this._id;
-});
 ResourceSchema.set('toJSON', {
   virtuals: true,
   getters: true,

--- a/app/models/testcase.js
+++ b/app/models/testcase.js
@@ -178,22 +178,15 @@ const TestCaseSchema = new Schema({
   }
 });
 
+TestCaseSchema.virtual('id').get(function getId() {
+  return this._id;
+});
+
 
 TestCaseSchema.set('toJSON', {
   virtuals: true,
   getters: true,
-  minimize: true,
-  transform(doc, ret) {
-    const jsonResource = ret;
-
-    if (!jsonResource.id) {
-      jsonResource.id = ret._id;
-    }
-
-    delete jsonResource._id;
-    delete jsonResource.__v;
-    return jsonResource;
-  }
+  minimize: true
 });
 
 TestCaseSchema.index({tcid: 1, 'ver.cur': -1}, {unique: true});

--- a/app/models/testcase.js
+++ b/app/models/testcase.js
@@ -178,11 +178,6 @@ const TestCaseSchema = new Schema({
   }
 });
 
-TestCaseSchema.virtual('id').get(function getId() {
-  return this._id;
-});
-
-
 TestCaseSchema.set('toJSON', {
   virtuals: true,
   getters: true,

--- a/test/tests_api/events.js
+++ b/test/tests_api/events.js
@@ -53,7 +53,7 @@ describe('Events', function () {
       .set('authorization', authString)
       .end()
       .then((response) => {
-        resourceId = response.body.id;
+        resourceId = response.body._id;
         resourceHwSn = response.body.hw.sn;
       });
   });

--- a/test/tests_api/resource.js
+++ b/test/tests_api/resource.js
@@ -55,10 +55,11 @@ describe('Resource', function () {
         expect(res).to.have.property('status', 200);
         expect(res.body).to.have.property('name');
         expect(res.body).to.have.property('type');
-        expect(res.body).to.have.property('id');
+        expect(res.body).to.have.property('_id');
+        expect(res.body).to.be.an('string');
         expect(res.body.name).to.equal('dev1');
         expect(res.body.type).to.equal('dut');
-        resourceId = res.body.id;
+        resourceId = res.body._id;
       });
   });
 
@@ -71,7 +72,8 @@ describe('Resource', function () {
         expect(res).to.have.property('status', 200);
         expect(res.body).to.have.property('name');
         expect(res.body).to.have.property('type');
-        expect(res.body).to.have.property('id');
+        expect(res.body).to.have.property('_id');
+        expect(res.body).to.be.an('string');
         expect(res.body.name).to.equal('dev1');
         expect(res.body.type).to.equal('dut');
       });
@@ -151,7 +153,7 @@ describe('Resource', function () {
       return superagent.post(`${api}/resources`)
         .send(body)
         .end(function (error, res) {
-          resourceId = res.body.id;
+          resourceId = res.body._id;
         });
     });
     after(function () {

--- a/test/tests_api/resource.js
+++ b/test/tests_api/resource.js
@@ -73,7 +73,7 @@ describe('Resource', function () {
         expect(res.body).to.have.property('name');
         expect(res.body).to.have.property('type');
         expect(res.body).to.have.property('_id');
-        expect(res.body).to.be.an('string');
+        expect(res.body._id).to.be.an('string');
         expect(res.body.name).to.equal('dev1');
         expect(res.body.type).to.equal('dut');
       });

--- a/test/tests_api/resource.js
+++ b/test/tests_api/resource.js
@@ -56,7 +56,7 @@ describe('Resource', function () {
         expect(res.body).to.have.property('name');
         expect(res.body).to.have.property('type');
         expect(res.body).to.have.property('_id');
-        expect(res.body).to.be.an('string');
+        expect(res.body._id).to.be.an('string');
         expect(res.body.name).to.equal('dev1');
         expect(res.body.type).to.equal('dut');
         resourceId = res.body._id;


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Testcase and Resource models has conversion for _id field and in API there was visible `id`. This PR consolidate id handling so that its same for each models - just mongo default `_id`.
-> Rename testcase and resource identify field: `id` -> `_id` that was done in toJSON transformer.

**NOTE:**
* **This is breaking change** - resource and test case identified field is changed from `id` -> `_id`.
* Does not affect opentmi-pyclient neither opentmi-jsclient because they expects already that `_id` field exists in these documents.


## Todos
- [x] Tests