### PR TITLE
remove default_gui submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "default-gui"]
-	path = app/addons/default-gui
-	url = https://github.com/OpenTMI/opentmi-default-gui.git


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES.  

default_gui is not included in git anymore and need to deploy separately.

## Description
This just simplify server side and allows more flexible way to deploy actual UI. 
Sometimes default_gui is not even needed or is replaced with custom one.
Anyway, default_gui can be deployed separately when needed just by dropping it under `app/addons/` folder.