### PR TITLE
Result model tune

### DIFF
--- a/app/models/results.js
+++ b/app/models/results.js
@@ -23,14 +23,8 @@ const Testcase = mongoose.model('Testcase');
 
 // @Todo justify why file schema is extended here instead of adding to root model
 FileSchema.add({
-  ref: {
-    type: ObjectId,
-    ref: 'Resource'
-  },
-  from: {
-    type: String,
-    enum: ['dut', 'framework', 'env', 'other']
-  }
+  ref: {type: ObjectId, ref: 'Resource'},
+  from: {type: String, enum: ['dut', 'framework', 'env', 'other']}
 });
 
 // Device(s) Under Test

--- a/app/models/results.js
+++ b/app/models/results.js
@@ -189,7 +189,10 @@ ResultSchema.pre('save', preSave);
 ResultSchema
   .virtual('exec.dut')
   .get(function dutGet() {
-    return _.get(this, 'exec.duts.0', {});
+    const duts = _.get(this, 'exec.duts', []);
+    const obj = duts.length === 1 ? duts[0].toJSON() : {};
+    obj.count = duts.length;
+    return obj;
   })
   .set(function dutSet(obj) {
     if (!this.exec.duts) {

--- a/app/models/results.js
+++ b/app/models/results.js
@@ -138,11 +138,11 @@ async function linkRelatedBuild(result) {
   }
 }
 async function linkTestcase(result) {
-  const {tcid} = result;
+  const {tcid, tcRef} = result;
   if (!tcid) {
     throw new Error('tcid is missing!');
   }
-  if (result.tcRef) {
+  if (tcRef) {
     return;
   }
   logger.debug(`Processing result tcid: ${tcid}`);
@@ -171,7 +171,7 @@ async function storeFile(file, i) {
 async function preSave(next) {
   try {
     // Link related objects
-    await linkTestcase(this, _.get(this, ''));
+    await linkTestcase(this);
     await linkRelatedBuild(this);
     const logs = _.get(this, 'exec.logs', []);
     await Promise.all(logs.map(storeFile));

--- a/app/models/results.js
+++ b/app/models/results.js
@@ -18,8 +18,6 @@ const {Types} = Schema;
 const {ObjectId, Mixed} = Types;
 const {filedb} = tools;
 const fileProvider = filedb.provider;
-const Build = mongoose.model('Build');
-const Testcase = mongoose.model('Testcase');
 
 // @Todo justify why file schema is extended here instead of adding to root model
 FileSchema.add({
@@ -132,7 +130,7 @@ async function linkRelatedBuild(result) {
     return;
   }
   logger.debug(`Processing result build sha1: ${buildChecksum}`);
-  const build = Build.findOne({'files.sha1': buildChecksum});
+  const build = mongoose.model('Build').findOne({'files.sha1': buildChecksum});
   if (build) {
     logger.debug(`Build found, linking Result: ${result._id} with Build: ${build._id}`);
     result.exec.sut.ref = build._id; // eslint-disable-line no-param-reassign
@@ -147,7 +145,7 @@ async function linkTestcase(result) {
     return;
   }
   logger.debug(`Processing result tcid: ${tcid}`);
-  const test = Testcase.findOne({tcid});
+  const test = mongoose.model('Testcase').findOne({tcid});
   if (test) {
     logger.debug(`Test found, linking Result: ${result._id} with Test: ${test._id}`);
     result.tcRef = test._id; // eslint-disable-line no-param-reassign
@@ -169,7 +167,7 @@ async function storeFile(file, i) {
   return Promise.resolve();
 }
 
-const preValidate = async (next) => {
+async function preValidate(next) {
   try {
     // Link related objects
     await linkTestcase(this, _.get(this, ''));
@@ -180,7 +178,7 @@ const preValidate = async (next) => {
   } catch (error) {
     next(error);
   }
-};
+}
 
 ResultSchema.pre('validate', preValidate);
 

--- a/test/tests_api/mocking/mockResult.json
+++ b/test/tests_api/mocking/mockResult.json
@@ -9,7 +9,7 @@
       "count": 1,
       "type": "hw"
     },
-    "duts": [{"type": "hw"}],
+    "duts": [{"type": "hw", "platform": "custom"}],
     "metadata": {"mymeta": 0},
     "metrics": {"heapmax": 0},
     "logs": [

--- a/test/tests_api/results.js
+++ b/test/tests_api/results.js
@@ -85,6 +85,7 @@ describe('Results', function () {
         expect(res.body.exec).to.have.property('duts').which.is.an('array');
         expect(res.body.exec.duts).to.have.lengthOf(1);
         expect(res.body.exec.dut).to.be.deep.equal(res.body.exec.duts[0]);
+        expect(res.body.exec.duts[0].platform).to.be.equal('custom');
 
         // Check log sanity
         expect(res.body.exec.logs[0]).to.not.have.property('data');

--- a/test/tests_api/results.js
+++ b/test/tests_api/results.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs');
 
 // Third party components
+const _ = require('lodash');
 const superagent = require('superagent');
 const {expect} = require('chai');
 const logger = require('winston');
@@ -84,8 +85,9 @@ describe('Results', function () {
         expect(res.body.exec.logs).to.have.lengthOf(1);
         expect(res.body.exec).to.have.property('duts').which.is.an('array');
         expect(res.body.exec.duts).to.have.lengthOf(1);
-        expect(res.body.exec.dut).to.be.deep.equal(res.body.exec.duts[0]);
+        expect(res.body.exec.dut).to.be.deep.equal(_.merge({count: 1}, res.body.exec.duts[0]));
         expect(res.body.exec.duts[0].platform).to.be.equal('custom');
+        expect(res.body.exec.duts[0].type).to.be.equal('hw');
 
         // Check log sanity
         expect(res.body.exec.logs[0]).to.not.have.property('data');

--- a/test/tests_api/results.js
+++ b/test/tests_api/results.js
@@ -84,6 +84,7 @@ describe('Results', function () {
         expect(res.body.exec.logs).to.have.lengthOf(1);
         expect(res.body.exec).to.have.property('duts').which.is.an('array');
         expect(res.body.exec.duts).to.have.lengthOf(1);
+        expect(res.body.exec.dut).to.be.deep.equal(res.body.exec.duts[0]);
 
         // Check log sanity
         expect(res.body.exec.logs[0]).to.not.have.property('data');


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
* mostly result related internal refactoring (es6 async/await usage)
* Add `platform: {type: String},` for duts object
* `exec.dut` -path is now virtual, virtual value is coming from from `exec.duts.0` object.
* link test case to result object when `tcid` exists but tcRef does not
* drop empty default values