### PR TITLE
improve single document get API

### DIFF
--- a/test/unittests/controller/resources.js
+++ b/test/unittests/controller/resources.js
@@ -32,7 +32,8 @@ describe('controllers/resources.js', function () {
     const req = newRequest({}, {Resource: '123'});
     const res = newResponse();
     const resource = {a: 1};
-    sinon.stub(controller._model, 'findOne').resolves(resource);
+    sinon.stub(controller._model, 'findOne').returns(controller._model);
+    sinon.stub(controller._model, 'populate').resolves(resource);
     return controller.modelParam(req, res, next)
       .then(() => {
         expect(next.called).to.be.true;


### PR DESCRIPTION
## Migrations
NO

## Description
allow to select (`f=<field>`), populate (`p=[<field>]|[<json>]`)
and use timeout (`to=<number>`) when get single document. Note same format than mongoose-query has which is used for many document search.

default timeout for single document get is 5s